### PR TITLE
Add support for Int and Float tags

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -34,15 +34,21 @@ export default class Emitter {
   // Preprocessing
 
   _preprocessNode(node:Types.Node, name:Types.SymbolName):boolean {
+    const specialTags = ['ID', 'Int', 'Float'];
+
     if (node.type === 'alias' && node.target.type === 'reference') {
       const referencedNode = this.types[node.target.target];
       if (this._isPrimitive(referencedNode) || referencedNode.type === 'enum') {
         this.renames[name] = node.target.target;
         return true;
       }
-    } else if (node.type === 'alias' && this._hasDocTag(node, 'ID')) {
-      this.renames[name] = 'ID';
-      return true;
+    } else if (node.type === 'alias') {
+      for (const tag of specialTags) {
+        if (this._hasDocTag(node, tag)) {
+          this.renames[name] = tag;
+          return true;
+        }
+      }
     }
 
     return false;


### PR DESCRIPTION
This PR provides the capacity of specifying to ts2gql if a TypeScript `number`is a `Float` or an `Int` so as to properly generate the appropriate GraphQL type. Before this, every number would be treated as Float.

To do this, you only need to add the `/** @graphql Int` or `/** @graphql Float*/` docstring before the desired number alias. For example:

```ts
declare global {
    /** @graphql ID */
    type ID = string
    /** @graphql Int */
    type Int = number
    /** @graphql Float */
    type Float = number
}

interface Book {
    id: ID
    price: Float
    year: Int
}

interface Query {
    book(args: {year: Int, price: Float}): Book
}

/** @graphql schema */
export interface Schema {
    query: Query
}
```

Generates:
```graphql
scalar Date

type Book {
  id: ID
  price: Float
  year: Int
}

type Query {
  book(year: Int, price: Float): Book
}

schema {
  query: Query
}
```