### PR TITLE
Add support for non nullable types

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -76,13 +76,17 @@ export default class Collector {
         value: _.trim((<typescript.LiteralTypeNode>node).literal.getText(), "'\""),
       };
     } else if (node.kind === SyntaxKind.StringKeyword) {
-      result = {type: 'string'};
+      result = {type: 'notnull', node: {type: 'string'}};
     } else if (node.kind === SyntaxKind.NumberKeyword) {
-      result = {type: 'number'};
+      result = {type: 'notnull', node: {type: 'number'}};
     } else if (node.kind === SyntaxKind.BooleanKeyword) {
-      result = {type: 'boolean'};
+      result = {type: 'notnull', node: {type: 'boolean'}};
     } else if (node.kind === SyntaxKind.AnyKeyword) {
       result = { type: 'any' };
+    } else if (node.kind === SyntaxKind.NullKeyword) {
+      result = {type: 'null'};
+    } else if (node.kind === SyntaxKind.UndefinedKeyword) {
+      result = {type: 'undefined'};
     } else if (node.kind === SyntaxKind.ModuleDeclaration) {
       // Nada.
     } else if (node.kind === SyntaxKind.VariableDeclaration) {
@@ -154,7 +158,7 @@ export default class Collector {
   }
 
   _walkTypeReferenceNode(node:typescript.TypeReferenceNode):types.Node {
-    return this._referenceForSymbol(this._symbolForNode(node.typeName));
+    return { type: 'notnull', node: this._referenceForSymbol(this._symbolForNode(node.typeName)) };
   }
 
   _walkTypeAliasDeclaration(node:typescript.TypeAliasDeclaration):types.Node {
@@ -218,8 +222,11 @@ export default class Collector {
 
   _walkArrayTypeNode(node:typescript.ArrayTypeNode):types.Node {
     return {
-      type: 'array',
-      elements: [this._walkNode(node.elementType)],
+      type: 'notnull',
+      node: {
+        type: 'array',
+        elements: [this._walkNode(node.elementType)]
+      }
     };
   }
 

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -153,10 +153,11 @@ export default class Collector {
   }
 
   _walkPropertySignature(node:typescript.PropertySignature):types.Node {
+    const signature = this._walkNode(node.type!)
     return {
       type: 'property',
       name: node.name.getText(),
-      signature: this._walkNode(node.type!),
+      signature: (node.questionToken && signature.type === 'notnull' ) ? signature.node : signature,
     };
   }
 

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -66,6 +66,9 @@ export default class Collector {
       result = this._walkEnumDeclaration(<typescript.EnumDeclaration>node);
     } else if (node.kind === SyntaxKind.TypeLiteral) {
       result = this._walkTypeLiteralNode(<typescript.TypeLiteralNode>node);
+    } else if (node.kind === SyntaxKind.ParenthesizedType) {
+      const parenthesizedNode = node as typescript.ParenthesizedTypeNode
+      result = this._walkNode(parenthesizedNode.type)
     } else if (node.kind === SyntaxKind.ArrayType) {
       result = this._walkArrayTypeNode(<typescript.ArrayTypeNode>node);
     } else if (node.kind === SyntaxKind.UnionType) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,19 @@ export interface AnyNode {
   type:'any';
 }
 
+export interface NullNode {
+  type:'null';
+}
+
+export interface UndefinedNode {
+  type:'undefined';
+}
+
+export interface NotNullNode {
+  type:'notnull';
+  node:Node;
+}
+
 export type Node =
   InterfaceNode |
   MethodNode |
@@ -91,6 +104,9 @@ export type Node =
   StringNode |
   NumberNode |
   BooleanNode |
+  NullNode |
+  UndefinedNode |
+  NotNullNode |
   AnyNode;
 
 export type NamedNode = MethodNode | PropertyNode;


### PR DESCRIPTION
This PR adds support to differentiate nullable from non nullable types. From now on, all types are non nullable by default. The developer may inform something is nullable by 2 ways:

1. Substituting the type for an union with `null`
2. Substituting the type for an union with `undefined`
3. For Interface properties, you may use the question mark `?` after the property name.

For example, the result of the schema.d.ts:
```ts

declare global {
  /** @graphql ID */
  type ID = string
  /** @graphql Int */
  type Int = number
}

interface Book {
  id: ID
  title: string
  subtitle?: string
  author: string
  year: Int | null
  publisher: string | undefined
}

interface Query {
  book(args: {id: ID | null}): Book | null
  books(args: {ids: (ID | undefined)[] | null}): Books[] | undefined
  booksByYear(args: {years: Int[] }): (Books | null)[] | null
}

/** @graphql schema */
export interface Schema {
  query: Query
}
```

Would be:

```graphql
scalar Date

type Book {
  author: String!
  id: ID!
  publisher: String
  subtitle: String
  title: String!
  year: Int
}

type Query {
  book(id: ID): Book
  books(ids: [ID]): [Book!]
  booksByYear(years: [Int!]!): [Book]
}

schema {
  query: Query
}
```