### PR TITLE
Removing scalar Date field from transpiled schema

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -12,9 +12,7 @@ const TypeFlags = typescript.TypeFlags;
  * referenced types.
  */
 export default class Collector {
-  types:types.TypeMap = {
-    Date: {type: 'alias', target: {type: 'string'}},
-  };
+  types:types.TypeMap = {};
   private checker:typescript.TypeChecker;
   private nodeMap:Map<typescript.Node, types.Node> = new Map();
 


### PR DESCRIPTION
This PR fixes the default adding of scalar Date to every schema transpiled with ts2gql.

Have no idea why the original repo had this built in.