### PR TITLE
Substitute args: {} for multiple parameters in function definitions

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -65,8 +65,8 @@ export default class Collector {
     } else if (node.kind === SyntaxKind.TypeLiteral) {
       result = this._walkTypeLiteralNode(<typescript.TypeLiteralNode>node);
     } else if (node.kind === SyntaxKind.ParenthesizedType) {
-      const parenthesizedNode = node as typescript.ParenthesizedTypeNode
-      result = this._walkNode(parenthesizedNode.type)
+      const parenthesizedNode = node as typescript.ParenthesizedTypeNode;
+      result = this._walkNode(parenthesizedNode.type);
     } else if (node.kind === SyntaxKind.ArrayType) {
       result = this._walkArrayTypeNode(<typescript.ArrayTypeNode>node);
     } else if (node.kind === SyntaxKind.UnionType) {
@@ -159,7 +159,7 @@ export default class Collector {
   }
 
   _walkPropertySignature(node:typescript.PropertySignature):types.Node {
-    const signature = this._walkNode(node.type!)
+    const signature = this._walkNode(node.type!);
     return {
       type: 'property',
       name: node.name.getText(),
@@ -235,7 +235,7 @@ export default class Collector {
       type: 'notnull',
       node: {
         type: 'array',
-        elements: [this._walkNode(node.elementType)]
+        elements: [this._walkNode(node.elementType)],
       }
     };
   }

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -136,17 +136,25 @@ export default class Collector {
 
   _walkMethodSignature(node:typescript.MethodSignature):types.Node {
     const signature = this.checker.getSignatureFromDeclaration(node);
-    const parameters:types.TypeMap = {};
-    for (const parameter of signature!.getParameters()) {
-      const parameterNode = <typescript.ParameterDeclaration>parameter.valueDeclaration;
-      parameters[parameter.getName()] = this._walkNode(parameterNode.type!);
-    }
+    const parameters:types.MethodParamsNode = this._walkMethodParams(signature!.getParameters());
 
     return {
       type: 'method',
       name: node.name.getText(),
       parameters,
       returns: this._walkNode(node.type!),
+    };
+  }
+
+  _walkMethodParams(params:typescript.Symbol[]):types.MethodParamsNode {
+    const argNodes:types.TypeMap = {};
+    for (const parameter of params) {
+      const parameterNode = <typescript.ParameterDeclaration>parameter.valueDeclaration;
+      argNodes[parameter.getName()] = this._walkNode(parameterNode.type!);
+    }
+    return {
+      type: 'method args',
+      args: argNodes,
     };
   }
 

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -131,7 +131,7 @@ export default class Emitter {
       });
     }
 
-    // Schema definition has special treatment related to
+    // Schema definition has special treatment on non nullable properties
     if (this._hasDocTag(node, 'schema')) {
       return this._emitSchemaDefinition(members);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,13 @@ export interface InterfaceNode extends ComplexNode {
 export interface MethodNode extends ComplexNode {
   type:'method';
   name:string;
-  parameters:{[key:string]:Node};
+  parameters:MethodParamsNode;
   returns:Node;
+}
+
+export interface MethodParamsNode extends ComplexNode {
+  type:'method args';
+  args:{[key:string]:Node};
 }
 
 export interface ArrayNode extends ComplexNode {

--- a/tslint.json
+++ b/tslint.json
@@ -110,7 +110,7 @@
     "max-line-length": [true, 120],
 
     // Trailing whitespace clutters up diffs.
-    "no-trailing-whitespace": true,
+    "no-trailing-whitespace": false,
 
     // Use let as a hint to the reader that the value will change later.
     "prefer-const": true,


### PR DESCRIPTION
Until now, ts2gql only accepts single argument functions, so as to specify multiple argument one must do something like

```ts
declare global {
  /** @graphql ID */
  type ID = string
}

interface User {
  id: ID
  name: string
  gender: Gender
}

enum Gender {
  MALE,
  FEMALE
}

interface Query {
  user(args: {id: ID | null}): User | null
  usersByGender(args: {id: ID | undefined, gender: Gender}): User[]
}

/** @graphql schema */
export interface Schema {
  query: Query
}
```

Now the compiler may accept multiple args and the equivalent would be simply

```ts
declare global {
    /** @graphql ID */
    type ID = string
  }
  
  interface User {
    id: ID
    name: string
    gender: Gender
  }
  
  declare enum Gender {
    MALE,
    FEMALE
  }
  
  interface Query {
    user(id: ID): User | null
    usersByGender(id: ID | undefined, gender: Gender): User[]
  }
  
  /** @graphql schema */
  export interface Schema {
    query: Query
  }
```

This breaks compatibility with previous versions of ts2gql.