### PR TITLE
Add Support to GraphQL Directives declarations through JSDoc

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -163,7 +163,6 @@ export default class Collector {
     if (directivesStart === -1) {
       return [];
     }
-    
     return _.map(jsDoc.tags.slice(directivesStart + 1), this._directiveFromDocTag);
   }
 
@@ -359,7 +358,6 @@ export default class Collector {
   _directiveFromDocTag(jsDocTag:doctrine.Tag):types.DirectiveNode {
     // This regex properly catches the parameters substring
     const paramsContentRegex = /\s*\(\s*((?:.|\s)*)\s*\)\s*/g;
-    
     let directiveParams = {
       type: types.NodeType.METHOD_PARAMS,
       args: {},
@@ -369,13 +367,12 @@ export default class Collector {
       if (!paramsContent) {
         throw new Error(`Invalid parameter description ${jsDocTag.description} at directive ${jsDocTag.title}.`);
       }
-
       const parser = new MethodParamsParser();
       try {
         directiveParams = parser.parse(paramsContent[0]);
       } catch (e) {
         const parsingMsg = e.message;
-        throw new Error(`Failed to parse parameter list of \"${jsDocTag.title}\" directive.\n${parsingMsg}`);      
+        throw new Error(`Failed to parse parameter list of \"${jsDocTag.title}\" directive.\n${parsingMsg}`);
       }
     }
     return {

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -368,10 +368,11 @@ export default class Collector {
       const parser = new MethodParamsParser(cleanedParams);
       try {
         directiveParams = parser.parse();
-      } catch (error) {
-        if (error instanceof InvalidParamsException) {
+      } catch (e) {
+        if (e instanceof InvalidParamsException) {
           throw new Error(`Error parsing parameter list of directive ${jsDocTag.title}.`);
         }
+        throw e;
       }
     }
     return {

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -165,9 +165,9 @@ export default class Collector {
     }
     const processedTags = {};
     return _.map(jsDoc.tags.slice(directivesStart + 1), (tag) => {
-      if (processedTags[`${tag.title}`])
+      if (processedTags[tag.title])
         throw new Error(`Multiple declarations of directive ${tag.title}.`);
-      processedTags[`${tag.title}`] = true;
+      processedTags[tag.title] = true;
       return this._directiveFromDocTag(tag);
     });
   }

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -183,7 +183,8 @@ export default class Emitter {
   _emitInterfaceMethod(member:Types.MethodNode):string {
     const parameters = `(${this._emitMethodArgs(member.parameters)})`;
     const returnType = this._emitExpression(member.returns);
-    return `${this._name(member.name)}${parameters}: ${returnType}`;
+    const methodDirectives = this._emitMethodDirectives(member.directives);
+    return `${this._name(member.name)}${parameters}: ${returnType} ${methodDirectives}`;
   }
 
   _emitMethodArgs(node:Types.MethodParamsNode):string {
@@ -199,6 +200,12 @@ export default class Emitter {
     }).join(', ');
   }
 
+  _emitMethodDirectives(directives:Types.DirectiveNode[]):string {
+    return _.map(directives, (directive:Types.DirectiveNode) => {
+      return `@${directive.name}(${this._emitMethodArgs(directive.params)})`;
+    }).join(' ');
+  }
+
   _emitEnum(node:Types.EnumNode, name:Types.SymbolName):string {
     return `enum ${this._name(name)} {\n${this._indent(node.values)}\n}`;
   }
@@ -206,6 +213,8 @@ export default class Emitter {
   _emitExpression = (node:Types.Node):string => {
     if (!node) {
       return '';
+    } else if (node.type === Types.NodeType.VALUE) {
+      return `${node.value}`;
     } else if (node.type === Types.NodeType.NOT_NULL) {
       return `${this._emitExpression(node.node)}!`;
     } else if (node.type === Types.NodeType.STRING) {

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -56,12 +56,12 @@ export default class Emitter {
   // Nodes
 
   _emitAlias(node:Types.AliasNode, name:Types.SymbolName):string {
-    if (this._isPrimitive(node.target) 
+    if (this._isPrimitive(node.target)
     || (node.target.type === Types.NodeType.NOT_NULL && this._isPrimitive(node.target.node))) {
       return `scalar ${this._name(name)}`;
-    } else if (node.target.type === Types.NodeType.REFERENCE || (node.target.type === Types.NodeType.NOT_NULL 
+    } else if (node.target.type === Types.NodeType.REFERENCE || (node.target.type === Types.NodeType.NOT_NULL
       && node.target.node.type === Types.NodeType.REFERENCE)) {
-      const target = node.target.type === Types.NodeType.REFERENCE 
+      const target = node.target.type === Types.NodeType.REFERENCE
       ? node.target : node.target.node as Types.ReferenceNode;
       return `union ${this._name(name)} = ${this._emitReference(target)}`;
     } else if (node.target.type === 'union') {
@@ -86,9 +86,9 @@ export default class Emitter {
     }
 
     const unionNodeTypes = node.types.map((type) => {
-      if (type.type !== Types.NodeType.REFERENCE && (type.type !== Types.NodeType.NOT_NULL 
+      if (type.type !== Types.NodeType.REFERENCE && (type.type !== Types.NodeType.NOT_NULL
         || type.node.type !== Types.NodeType.REFERENCE )) {
-        const msg = 'GraphQL unions require that all types are references. Got a ' 
+        const msg = 'GraphQL unions require that all types are references. Got a '
         + (type.type === Types.NodeType.NOT_NULL ? type.node.type : type.type);
         throw new Error(msg);
 
@@ -100,7 +100,7 @@ export default class Emitter {
     const firstChildType = this.types[firstChild.target];
 
     if (firstChildType.type === Types.NodeType.ENUM) {
-      const nodeTypes = node.types.map((type:Types.ReferenceNode) => {
+      const nodeTypes = unionNodeTypes.map((type:Types.ReferenceNode) => {
         const subNode = this.types[type.target];
         if (subNode.type !== Types.NodeType.ENUM) {
           throw new Error(`ts2gql expected a union of only enums since first child is an enum. Got a ${type.type}`);
@@ -114,7 +114,7 @@ export default class Emitter {
       }, this._name(name));
 
     } else if (firstChildType.type === Types.NodeType.INTERFACE) {
-      const nodeNames = node.types.map((type:Types.ReferenceNode) => {
+      const nodeNames = unionNodeTypes.map((type:Types.ReferenceNode) => {
 
         const subNode = this.types[type.target];
         if (subNode.type !== Types.NodeType.INTERFACE) {
@@ -317,7 +317,7 @@ export default class Emitter {
   }
 
   _isPrimitive(node:Types.Node):boolean {
-    return node.type === Types.NodeType.STRING || node.type === Types.NodeType.NUMBER 
+    return node.type === Types.NodeType.STRING || node.type === Types.NodeType.NUMBER
     || node.type === Types.NodeType.BOOLEAN || node.type === Types.NodeType.ANY;
   }
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,0 +1,122 @@
+import * as types from './types';
+import * as _ from 'lodash';
+
+export interface PartialParseResult {
+    nextIdx:number;
+}
+
+export interface ArgNameParseResult extends PartialParseResult {
+    argName:string;
+}
+
+export interface ArgValueParseResult extends PartialParseResult {
+    argValue:types.ValueNode;
+}
+
+export class InvalidParamsException extends Error {
+    constructor() {
+        super("Invalid parameter list.");
+    }
+}
+
+export class MethodParamsParser  {
+    public token:string;
+    private limit:number;
+    private args:types.TypeMap;
+
+    constructor(token:string) {
+        this.token = token;
+        this.limit = token.length;
+        this.args = {};
+    }
+
+    parse():types.MethodParamsNode {
+        return {
+            type: types.NodeType.METHOD_PARAMS,
+            args: this._parseArgs(),
+        };
+    }
+
+    _parseArgs():types.TypeMap {
+        if (!this.token || this.token[0] !== '(' || this.token[this.limit - 1] !== ')') {
+            throw new InvalidParamsException();
+        }
+        let argStart = 1;
+        while (argStart < this.limit && this.token[argStart] !== ')') {
+            argStart = this._parseArg(argStart);
+        }
+
+        return this.args;
+    }
+
+    _parseArg(startIdx:number):number {
+        const argNameParseResult = this._parseArgName(startIdx);
+        const argValueParseResult = this._parseArgValue(argNameParseResult.nextIdx);
+
+        if (this.args[argNameParseResult.argName]) {
+            throw new InvalidParamsException();
+        }
+        this.args[argNameParseResult.argName] = argValueParseResult.argValue;
+
+        return argValueParseResult.nextIdx;
+    }
+
+    _parseArgName(startIdx:number):ArgNameParseResult {
+        if (this.token[startIdx].match(/[^A-Za-z]/) || !this._checkIndex(startIdx)) {
+            throw new InvalidParamsException();
+        }
+        let pointer = startIdx + 1;
+        while (true) {
+            if (this.token[pointer] === ':') break;
+            if (this.token[pointer].match(/[^\w]/) || pointer === this.limit) {
+                throw new InvalidParamsException();
+            }
+            pointer++;
+        }
+        
+        return {
+            argName: this.token.slice(startIdx, pointer),
+            nextIdx: pointer + 1,
+        };
+    }
+
+    _parseArgValue(startIdx:number):ArgValueParseResult {
+        if (!this._checkIndex(startIdx)) {
+            throw new InvalidParamsException();
+        }
+
+        const stringLiteralDelimiters = ['\'', '"'];
+        const literalIdx = _.findIndex(stringLiteralDelimiters, (delimiter) => delimiter === this.token[startIdx]);
+
+        let commaIdx;
+        let endIdx;
+        if (literalIdx !== -1) {
+            // We have a string literal, let's search for value end only after its definition end
+            const delimiter = stringLiteralDelimiters[literalIdx];
+            const literalEndIdx = this.token.indexOf(delimiter, startIdx + 1);
+            if (literalEndIdx === startIdx) {
+                throw new InvalidParamsException();
+            }
+
+            commaIdx = this.token.indexOf(',', literalEndIdx + 1);
+        } else {
+            commaIdx = this.token.indexOf(',', startIdx);
+        }
+        
+        // If there's no comma, it's last value
+        endIdx = commaIdx !== -1 ? commaIdx : this.limit - 1;
+
+        return {
+            argValue: {
+                type: types.NodeType.VALUE,
+                value: this.token.slice(startIdx, endIdx),
+            },
+            nextIdx: endIdx + 1,
+        };
+    }
+
+    _checkIndex(idx:number):boolean {
+        return idx >= 0 && idx < this.limit;
+    }
+
+}

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,4 +1,3 @@
-import { ArgValueParseResult } from './Parser';
 import * as types from './types';
 import { MethodParamsTokenizer, MethodParamsToken, TokenType } from './Tokenizer';
 
@@ -39,10 +38,10 @@ export class MethodParamsParser  {
         if (!this.tokens || this.tokens[0].type !== TokenType.PARAMETER_LIST_BEGIN) {
             throw new ParsingFailedException(`Token list created without beginning token.`);
         }
-        let argIdx = 1; 
+        let argIdx = 1;
         while (this.tokens[argIdx].type !== TokenType.PARAMETER_LIST_END) {
             if (argIdx > 1) {
-                if (this.tokens[argIdx].type !== TokenType.PARAMETER_SEPARATOR) 
+                if (this.tokens[argIdx].type !== TokenType.PARAMETER_SEPARATOR)
                     throw new ParsingFailedException(`Expected separators between parameters in parameter list.`);
                 argIdx++;
             }
@@ -56,10 +55,10 @@ export class MethodParamsParser  {
         const nameToken = this.tokens[start];
         const nameValueSeparatorToken = this.tokens[start + 1];
         const valueToken = this.tokens[start + 2];
-        if (nameToken.type !== TokenType.PARAMETER_NAME 
-        || nameValueSeparatorToken.type !== TokenType.PARAMETER_NAME_VALUE_SEPARATOR 
+        if (nameToken.type !== TokenType.PARAMETER_NAME
+        || nameValueSeparatorToken.type !== TokenType.PARAMETER_NAME_VALUE_SEPARATOR
         || valueToken.type !== TokenType.PARAMETER_VALUE) {
-            throw new ParsingFailedException(`Invalid token sequence for parameter list: 
+            throw new ParsingFailedException(`Invalid token sequence for parameter list:
             \n${nameToken.type}: ${nameToken.value}
             \n${nameValueSeparatorToken.type}: ${nameValueSeparatorToken.value}
             \n${valueToken.type}: ${valueToken.value}`);
@@ -72,7 +71,7 @@ export class MethodParamsParser  {
             type: types.NodeType.VALUE,
             value: valueToken.value,
         };
-        
+
         return start + 3;
     }
 }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,6 +1,6 @@
 import { ArgValueParseResult } from './Parser';
 import * as types from './types';
-import * as _ from 'lodash';
+import { MethodParamsTokenizer, MethodParamsToken, TokenType } from './Tokenizer';
 
 export interface PartialParseResult {
     nextIdx:number;
@@ -14,22 +14,21 @@ export interface ArgValueParseResult extends PartialParseResult {
     argValue:types.ValueNode;
 }
 
-export class InvalidParamsException extends Error {}
-
 export class ParsingFailedException extends Error {}
 
 export class MethodParamsParser  {
-    public token:string;
-    private limit:number;
+    private tokenizer:MethodParamsTokenizer;
+    private tokens:MethodParamsToken[];
     private args:types.TypeMap;
 
-    constructor(token:string) {
-        this.token = token;
-        this.limit = token.length;
+    constructor() {
+        this.tokenizer = new MethodParamsTokenizer();
+        this.tokens = [];
         this.args = {};
     }
 
-    parse():types.MethodParamsNode {
+    parse(stringToParse:string):types.MethodParamsNode {
+        this.tokens = this.tokenizer.tokenize(stringToParse);
         return {
             type: types.NodeType.METHOD_PARAMS,
             args: this._parseArgs(),
@@ -37,95 +36,43 @@ export class MethodParamsParser  {
     }
 
     _parseArgs():types.TypeMap {
-        if (!this.token || this.token[0] !== '(' || this.token[this.limit - 1] !== ')') {
-            throw new InvalidParamsException('Mismatching parenthesis at parameter list definition');
+        if (!this.tokens || this.tokens[0].type !== TokenType.PARAMETER_LIST_BEGIN) {
+            throw new ParsingFailedException(`Token list created without beginning token.`);
         }
-        let argStart = 1;
-        while (argStart < this.limit && this.token[argStart] !== ')') {
-            argStart = this._parseArg(argStart);
+        let argIdx = 1; 
+        while (this.tokens[argIdx].type !== TokenType.PARAMETER_LIST_END) {
+            if (argIdx > 1) {
+                if (this.tokens[argIdx].type !== TokenType.PARAMETER_SEPARATOR) 
+                    throw new ParsingFailedException(`Expected separators between parameters in parameter list.`);
+                argIdx++;
+            }
+            argIdx = this._parseArg(argIdx);
         }
 
         return this.args;
     }
 
-    _parseArg(startIdx:number):number {
-        const argNameParseResult = this._parseArgName(startIdx);
-        let argValueParseResult;
-        try {
-            argValueParseResult = this._parseArgValue(argNameParseResult.nextIdx);
-        } catch (e) {
-            e.message = `${e.message} at parameter ${argNameParseResult.argName}.`;
-            throw e;
+    _parseArg(start:number):number {
+        const nameToken = this.tokens[start];
+        const nameValueSeparatorToken = this.tokens[start + 1];
+        const valueToken = this.tokens[start + 2];
+        if (nameToken.type !== TokenType.PARAMETER_NAME 
+        || nameValueSeparatorToken.type !== TokenType.PARAMETER_NAME_VALUE_SEPARATOR 
+        || valueToken.type !== TokenType.PARAMETER_VALUE) {
+            throw new ParsingFailedException(`Invalid token sequence for parameter list: 
+            \n${nameToken.type}: ${nameToken.value}
+            \n${nameValueSeparatorToken.type}: ${nameValueSeparatorToken.value}
+            \n${valueToken.type}: ${valueToken.value}`);
         }
 
-        if (this.args[argNameParseResult.argName]) {
-            throw new InvalidParamsException(`Repeated param name ${argNameParseResult.argName}.`);
+        if (this.args[nameToken.value]) {
+            throw new ParsingFailedException(`Repeated param name ${nameToken.value}.`);
         }
-        this.args[argNameParseResult.argName] = argValueParseResult.argValue;
-
-        return argValueParseResult.nextIdx;
-    }
-
-    _parseArgName(startIdx:number):ArgNameParseResult {
-        if (!this._checkIndexBound(startIdx)) {
-            throw new ParsingFailedException('Unexpected end of parameter name.');
-        }
-        if (this.token[startIdx].match(/[^A-Za-z]/)) {
-            throw new InvalidParamsException(`Invalid character ${this.token[startIdx]} in parameter name.`);
-        }
-        let pointer = startIdx + 1;
-        while (true) {
-            const char = this.token[pointer];
-            if (char === ':') break;
-            if (char.match(/[^\w]/) || pointer === this.limit) {
-                throw new InvalidParamsException('Invalid character ' + char + 
-                ' at name ' + this.token.slice(startIdx, pointer) + '.');
-            }
-            pointer++;
-        }
-        
-        return {
-            argName: this.token.slice(startIdx, pointer),
-            nextIdx: pointer + 1,
+        this.args[nameToken.value] = {
+            type: types.NodeType.VALUE,
+            value: valueToken.value,
         };
-    }
-
-    _parseArgValue(startIdx:number):ArgValueParseResult {
-        if (!this._checkIndexBound(startIdx)) {
-            throw new ParsingFailedException('Unexpected end of parameter value');
-        }
-
-        const stringLiteralDelimiters = ['\'', '"'];
-        const literalIdx = _.findIndex(stringLiteralDelimiters, (delimiter) => delimiter === this.token[startIdx]);
-
-        let commaIdx;
-        if (literalIdx !== -1) {
-            // We have a string literal, let's search for value end only after its definition end
-            const delimiter = stringLiteralDelimiters[literalIdx];
-            const literalEndIdx = this.token.indexOf(delimiter, startIdx + 1);
-            if (literalEndIdx === startIdx) {
-                throw new InvalidParamsException(`Mismatched ${delimiter} delimiter in string literal`);
-            }
-
-            commaIdx = this.token.indexOf(',', literalEndIdx + 1);
-        } else {
-            commaIdx = this.token.indexOf(',', startIdx);
-        }
         
-        // If there's no comma, it's last value
-        const endIdx = commaIdx !== -1 ? commaIdx : this.limit - 1;
-
-        return {
-            argValue: {
-                type: types.NodeType.VALUE,
-                value: this.token.slice(startIdx, endIdx),
-            },
-            nextIdx: endIdx + 1,
-        };
+        return start + 3;
     }
-
-    _checkIndexBound(idx:number):boolean {
-        return idx >= 0 && idx < this.limit;
-    }
-
 }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -86,7 +86,7 @@ export class MethodParamsTokenizer {
             idx = this.parameterValue(idx);
         } catch (e) {
             const paramName = this.tokens[this.tokens.length - 2].value;
-            e.message = `${e.message} in parameter ${paramName}.`;
+            e.message = `${e.message} in parameter '${paramName}'.`;
             throw e;
         }
         return this._ignore(/\s/, idx);
@@ -124,13 +124,13 @@ export class MethodParamsTokenizer {
         const literalEndRegex = new RegExp(`(?:[^\\\\](?:\\\\{2})*)${delimiter}`);
         const result = literalEndRegex.exec(this.raw.slice(idx));
         if (result === null) {
-            throw new MethodParamsTokenizerException(`Mismatched string literal delimiter '${delimiter}'.`);
+            throw new MethodParamsTokenizerException(`Mismatched string literal delimiter '${delimiter}'`);
         }
 
         const matchBegin = idx + result.index;
         const matchLength = result[0].length;
         if (this.raw.slice(idx, matchBegin + matchLength).match(/\n/)) {
-            throw new MethodParamsTokenizerException(`Invalid multiline string literal.`);
+            throw new MethodParamsTokenizerException(`Invalid multiline string literal`);
         }
 
         const literalEnd = matchBegin + matchLength;

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -147,39 +147,11 @@ export class MethodParamsTokenizer {
     }
 
     _checkNameValue(value:string):boolean {
-        // A name must not start with digits, or have non word characters
         return !value.match(/^\d/) && !value.match(/\W/);
     }
 
     _checkNumberValue(value:string):boolean {
-        // There should be a - at most once and always in the beginning of value
-        const minusPos = value.lastIndexOf('-');
-        if (minusPos > 0) {
-            return false;
-        }
-        const positiveNumber =  minusPos === -1 ? value : value.slice(1);
-
-        if (value.match(/\./)) {
-            return this._checkPositiveFloatValue(positiveNumber);
-        }
-        return this._checkPositiveIntValue(positiveNumber);
-    }
-
-    _checkPositiveFloatValue(value:string):boolean {
-        // There should be a unique . separator with at least one algarism before and after
-        const dots = value.match(/\./g);
-        const dotIdx = value.indexOf('.');
-        return dots !== null && dots.length === 1 && dotIdx !== value.length - 1
-        && this._checkPositiveIntValue(value.slice(0, dotIdx))
-        && this._checkDecimalValue(value.slice(dotIdx + 1));
-    }
-
-    _checkPositiveIntValue(value:string):boolean {
-        return value.length > 0 && !value.match(/\D/) && (value.length === 1 || !value.match(/^0/));
-    }
-
-    _checkDecimalValue(value:string):boolean {
-        return value.length > 0 && !value.match(/\D/);
+        return !isNaN(Number(value).valueOf());
     }
 
     _ignore(ignore:RegExp, start:number):number {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -58,13 +58,13 @@ export class MethodParamsTokenizer {
 
         if (idx === this.raw.length)
             throw new MethodParamsTokenizerException('Expected ) at the end of parameter list declaration.');
-        
+
         this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_LIST_END, this.raw[idx]));
     }
 
     parameter(idx:number):number {
         idx = this.parameterName(idx);
-        
+
         if (this.raw[idx] !== ':') {
             const lastName = this.tokens[this.tokens.length - 1].value;
             throw new MethodParamsTokenizerException(`Expected : after parameter ${lastName}.`);
@@ -87,7 +87,7 @@ export class MethodParamsTokenizer {
         const name = this.raw.slice(idx, nameEnd);
         if (!name)
             throw new MethodParamsTokenizerException(`Expected parameter name, found ${this.raw[idx]}`);
-        
+
         this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_NAME, name));
         return nameEnd;
     }
@@ -95,12 +95,12 @@ export class MethodParamsTokenizer {
     parameterValue(idx:number):number {
         if (this.raw[idx].match(/('|")/))
             return this.stringLiteral(idx);
-        
+
         const valueEnd = this._until(/\s|,|\)/, idx);
         const value = this.raw.slice(idx, valueEnd);
         if (!this._checkPrimitiveValue(value))
             throw new MethodParamsTokenizerException(`Invalid value ${value}`);
-        
+
         this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_VALUE, value));
         return valueEnd;
     }
@@ -112,7 +112,7 @@ export class MethodParamsTokenizer {
         if (this.raw.slice(matchedEnd, matchedEnd + matchStep).match(/\n/)) {
             throw new MethodParamsTokenizerException(`Invalid multiline string literal`);
         }
-        
+
         const literalEnd = matchedEnd + matchStep;
         if (this.raw[literalEnd - 1] !== delimiter) {
             throw new MethodParamsTokenizerException(`Mismatched string literal delimiter ${delimiter}.`);
@@ -154,8 +154,8 @@ export class MethodParamsTokenizer {
     _checkPositiveFloatValue(value:string):boolean {
         const dots = value.match(/\./g);
         const dotIdx = value.indexOf('.');
-        return dots !== null && dots.length === 1 && dotIdx !== value.length - 1 
-        && this._checkPositiveIntValue(value.slice(0, dotIdx)) 
+        return dots !== null && dots.length === 1 && dotIdx !== value.length - 1
+        && this._checkPositiveIntValue(value.slice(0, dotIdx))
         && this._checkDecimalValue(value.slice(dotIdx + 1));
     }
 
@@ -167,17 +167,17 @@ export class MethodParamsTokenizer {
         return value.length > 0 && !value.match(/\D/);
     }
 
-    _ignore(ignore:RegExp, start:number, sublen = 1):number {
+    _ignore(ignore:RegExp, start:number, step = 1):number {
         let iterator = start;
-        while (iterator < this.raw.length - sublen + 1 && this.raw.slice(iterator, iterator + sublen).match(ignore)) {
+        while (iterator < this.raw.length - step + 1 && this.raw.slice(iterator, iterator + step).match(ignore)) {
             iterator++;
         }
         return iterator;
     }
 
-    _until(ignore:RegExp, start:number, sublen = 1):number {
+    _until(ignore:RegExp, start:number, step = 1):number {
         let iterator = start;
-        while (iterator < this.raw.length - sublen + 1 && !this.raw.slice(iterator, iterator + sublen).match(ignore)) {
+        while (iterator < this.raw.length - step + 1 && !this.raw.slice(iterator, iterator + step).match(ignore)) {
             iterator++;
         }
         return iterator;

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -1,0 +1,133 @@
+export enum TokenType {
+    PARAMETER_LIST_BEGIN,
+    PARAMETER_NAME,
+    PARAMETER_NAME_VALUE_SEPARATOR,
+    PARAMETER_VALUE,
+    PARAMETER_SEPARATOR,
+    PARAMETER_LIST_END,
+}
+
+export class MethodParamsToken {
+    public type:TokenType;
+    public value:string;
+
+    constructor(type:TokenType, value:string) {
+        this.type = type;
+        this.value = value;
+    }
+}
+
+export class MethodParamsTokenizerException extends Error {}
+
+export class MethodParamsTokenizer {
+    private tokens:MethodParamsToken[];
+    private raw:string;
+
+    constructor() {
+        this.tokens = [];
+        this.raw = '';
+    }
+
+    tokenize(content:string):MethodParamsToken[] {
+        delete this.tokens;
+        this.tokens = [];
+
+        this.raw = content;
+        this.begin(0);
+
+        return this.tokens;
+    }
+
+    begin(idx:number) {
+        if ( this.raw[idx] !== '(') {
+            throw new MethodParamsTokenizerException('Expected ( before parameter list declaration.');
+        }
+
+        this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_LIST_BEGIN, this.raw[idx]));
+        idx = this._ignore(/\s/, idx + 1);
+        while (idx < this.raw.length && this.raw[idx] !== ')') {
+            if (this.tokens.length > 1) {
+                if (this.raw[idx] !== ',') {
+                    throw new MethodParamsTokenizerException('Expected , between parameter definitions.');
+                }
+                this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_SEPARATOR, ','));
+                idx = this._ignore(/\s/, idx + 1);
+            }
+            idx = this.parameter(idx);
+        }
+
+        if (idx === this.raw.length)
+            throw new MethodParamsTokenizerException('Expected ) at the end of parameter list declaration.');
+        
+        this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_LIST_END, this.raw[idx]));
+    }
+
+    parameter(idx:number):number {
+        idx = this.parameterName(idx);
+        
+        if (this.raw[idx] !== ':') {
+            const lastName = this.tokens[this.tokens.length - 1].value;
+            throw new MethodParamsTokenizerException(`Expected : after parameter ${lastName}.`);
+        }
+        this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_NAME_VALUE_SEPARATOR, this.raw[idx]));
+
+        idx = this._ignore(/\s/, idx + 1);
+        idx = this.parameterValue(idx);
+        return this._ignore(/\s/, idx);
+    }
+
+    parameterName(idx:number):number {
+        const nameEnd = this._ignore(/\w/, idx);
+        const name = this.raw.slice(idx, nameEnd);
+        if (!name)
+            throw new MethodParamsTokenizerException(`Expected parameter name, found ${this.raw[idx]}`);
+        
+        this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_NAME, name));
+        return nameEnd;
+    }
+
+    parameterValue(idx:number):number {
+        if (this.raw[idx].match(/'|"/))
+            return this.stringLiteral(idx);
+        
+        const valueEnd = this._ignore(/\w|\./, idx);
+        const value = this.raw.slice(idx, valueEnd);
+        if (!value.match(/\w/) || (value.match(/[A-Z]/i) && value.match(/^\d/)) 
+        || (value.match(/[A-Z]/i) && value.match(/\./)))
+            throw new MethodParamsTokenizerException(`Invalid parameter value ${value}`);
+        
+        this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_VALUE, value));
+        return valueEnd;
+    }
+
+    stringLiteral(idx:number):number {
+        const delimiter = this.raw[idx];
+        const matchStep = 2;
+        const matchedEnd = this._until(new RegExp(`([^\\\\]${delimiter})|\\n`), idx, matchStep);
+        if (this.raw.slice(matchedEnd, matchedEnd + matchStep).match(/\n/)) {
+            throw new MethodParamsTokenizerException(`Invalid multiline string literal`);
+        }
+        
+        const literalEnd = matchedEnd + matchStep;
+        const literal = this.raw.slice(idx, literalEnd);
+        this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_VALUE, literal));
+        return literalEnd;
+    }
+
+    _ignore(ignore:RegExp, start:number, sublen = 1):number {
+        let iterator = start;
+        while (iterator < this.raw.length - sublen + 1 && this.raw.slice(iterator, iterator + sublen).match(ignore)) {
+            iterator++;
+        }
+        return iterator;
+    }
+
+    _until(ignore:RegExp, start:number, sublen = 1):number {
+        let iterator = start;
+        while (start < this.raw.length && !this.raw.slice(iterator, iterator + sublen).match(ignore)) {
+            iterator++;
+        }
+        return iterator;
+    }
+
+}

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -177,7 +177,7 @@ export class MethodParamsTokenizer {
 
     _until(ignore:RegExp, start:number, sublen = 1):number {
         let iterator = start;
-        while (iterator < this.raw.length && !this.raw.slice(iterator, iterator + sublen).match(ignore)) {
+        while (iterator < this.raw.length - sublen + 1 && !this.raw.slice(iterator, iterator + sublen).match(ignore)) {
             iterator++;
         }
         return iterator;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { ComplexNode } from './../dist/src/types.d';
 import * as doctrine from 'doctrine';
 
 export type SymbolName = string;
@@ -6,92 +7,119 @@ export interface ComplexNode {
   documentation?:doctrine.ParseResult;
 }
 
+export enum NodeType {
+  INTERFACE = 'interface',
+  METHOD = 'method',
+  METHOD_PARAMS = 'method params',
+  DIRECTIVE = 'directive',
+  ARRAY = 'array',
+  REFERENCE = 'reference',
+  PROPERTY = 'property',
+  ALIAS = 'alias',
+  ENUM = 'enum',
+  UNION = 'union',
+  LITERAL_OBJECT = 'literal object',
+  STRING_LITERAL = 'string literal',
+  STRING = 'string',
+  NUMBER = 'number',
+  BOOLEAN = 'boolean',
+  ANY = 'any',
+  NULL = 'null',
+  UNDEFINED = 'undefined',
+  NOT_NULL = 'not null',
+}
+
 export interface InterfaceNode extends ComplexNode {
-  type:'interface';
+  type:NodeType.INTERFACE;
   members:NamedNode[];
   inherits:SymbolName[];
   concrete?:boolean; // Whether the type is directly used (returned).
 }
 
 export interface MethodNode extends ComplexNode {
-  type:'method';
+  type:NodeType.METHOD;
   name:string;
   parameters:MethodParamsNode;
   returns:Node;
+  directives?:DirectiveNode[];
 }
 
 export interface MethodParamsNode extends ComplexNode {
-  type:'method args';
+  type:NodeType.METHOD_PARAMS;
   args:{[key:string]:Node};
 }
 
+export interface DirectiveNode extends ComplexNode {
+  type:NodeType.DIRECTIVE;
+}
+
 export interface ArrayNode extends ComplexNode {
-  type:'array';
+  type:NodeType.ARRAY;
   elements:Node[];
 }
 
 export interface ReferenceNode extends ComplexNode {
-  type:'reference';
+  type:NodeType.REFERENCE;
   target:SymbolName;
 }
 
 export interface PropertyNode extends ComplexNode {
-  type:'property';
+  type:NodeType.PROPERTY;
   name:string;
   signature:Node;
 }
 
 export interface AliasNode extends ComplexNode {
-  type:'alias';
+  type:NodeType.ALIAS;
   target:Node;
 }
 
 export interface EnumNode extends ComplexNode {
-  type:'enum';
+  type:NodeType.ENUM;
   values:string[];
 }
 
 export interface UnionNode extends ComplexNode {
-  type:'union';
+  type:NodeType.UNION;
   types:Node[];
 }
 
 export interface LiteralObjectNode {
-  type:'literal object';
+  type:NodeType.LITERAL_OBJECT;
   members:Node[];
 }
 
 export interface StringLiteralNode {
-  type:'string literal';
+  type:NodeType.STRING_LITERAL;
   value:string;
 }
 
 export interface StringNode {
-  type:'string';
+  type:NodeType.STRING;
 }
 
 export interface NumberNode {
-  type:'number';
+  type:NodeType.NUMBER;
 }
 
 export interface BooleanNode {
-  type:'boolean';
+  type:NodeType.BOOLEAN;
 }
 
 export interface AnyNode {
-  type:'any';
+  type:NodeType.ANY;
 }
 
 export interface NullNode {
-  type:'null';
+  type:NodeType.NULL;
 }
 
 export interface UndefinedNode {
-  type:'undefined';
+  type:NodeType.UNDEFINED;
 }
 
 export interface NotNullNode {
-  type:'notnull';
+  type:NodeType.NOT_NULL;
   node:Node;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,11 @@
-import { ComplexNode } from './../dist/src/types.d';
 import * as doctrine from 'doctrine';
+import { MethodParamsParser } from './Parser';
 
 export type SymbolName = string;
 
 export interface ComplexNode {
   documentation?:doctrine.ParseResult;
+  type:NodeType;
 }
 
 export enum NodeType {
@@ -27,6 +28,7 @@ export enum NodeType {
   NULL = 'null',
   UNDEFINED = 'undefined',
   NOT_NULL = 'not null',
+  VALUE = 'value',
 }
 
 export interface InterfaceNode extends ComplexNode {
@@ -41,16 +43,18 @@ export interface MethodNode extends ComplexNode {
   name:string;
   parameters:MethodParamsNode;
   returns:Node;
-  directives?:DirectiveNode[];
+  directives:DirectiveNode[];
 }
 
 export interface MethodParamsNode extends ComplexNode {
   type:NodeType.METHOD_PARAMS;
-  args:{[key:string]:Node};
+  args:TypeMap;
 }
 
 export interface DirectiveNode extends ComplexNode {
   type:NodeType.DIRECTIVE;
+  name:string;
+  params:MethodParamsNode;
 }
 
 export interface ArrayNode extends ComplexNode {
@@ -123,6 +127,11 @@ export interface NotNullNode {
   node:Node;
 }
 
+export interface ValueNode {
+  type:NodeType.VALUE;
+  value:string;
+}
+
 export type Node =
   InterfaceNode |
   MethodNode |
@@ -140,8 +149,17 @@ export type Node =
   NullNode |
   UndefinedNode |
   NotNullNode |
-  AnyNode;
+  AnyNode | 
+  ValueNode;
 
 export type NamedNode = MethodNode | PropertyNode;
 
 export type TypeMap = {[key:string]:Node};
+
+export interface Parser<T> {
+  result:T;
+}
+
+export interface MethodParamsParser extends Parser<MethodParamsNode> {
+
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,7 +149,7 @@ export type Node =
   NullNode |
   UndefinedNode |
   NotNullNode |
-  AnyNode | 
+  AnyNode |
   ValueNode;
 
 export type NamedNode = MethodNode | PropertyNode;

--- a/tslint.json
+++ b/tslint.json
@@ -110,7 +110,7 @@
     "max-line-length": [true, 120],
 
     // Trailing whitespace clutters up diffs.
-    "no-trailing-whitespace": false,
+    "no-trailing-whitespace": true,
 
     // Use let as a hint to the reader that the value will change later.
     "prefer-const": true,


### PR DESCRIPTION
This feature allows the transpiler to generate GraphQL Directives for GraphQL Fields. Description of the directives is done by using JSDoc and tags. Multiple directives are allowed. Basic usage of the feature would be:

```ts
declare global {
    /** @graphql ID */
    type ID = string
    /** @graphql Int */
    type Int = number
  }
  
  interface Book {
    authors?: string[]
    id: ID
    title: string
    year?: Int
  }
  
  interface Query {
    /** @graphql Directives
    * @response (vary: "x-vtex-segment")
    * @cacheControl (scope: PUBLIC, maxAge: SHORT)
    */
    book(id: ID): Book
    /** @graphql Directives
     * @someDirective (minStock: 1000)
     * @someOptimization (weight: 0.54)
     */
    booksByYear(years: Int[]): Book[]
  }
  
  /** @graphql schema */
  export interface Schema {
    query: Query
  }
```

In this example the result is

```gql

type Book {
  authors: [String!]
  id: ID!
  title: String!
  year: Int
}

type Query {
  book(id: ID!): Book! @response(vary: "x-vtex-segment") @cacheControl(scope: PUBLIC, maxAge: SHORT)
  booksByYear(years: [Int!]!): [Book!]! @someDirective(minStock: 1000) @someOptimization(weight: 0.54)
}

schema {
  query: Query
}
```