### PR TITLE
Fix emition of directives with no arguments

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -202,7 +202,11 @@ export default class Emitter {
 
   _emitMethodDirectives(directives:Types.DirectiveNode[]):string {
     return _.map(directives, (directive:Types.DirectiveNode) => {
-      return `@${directive.name}(${this._emitMethodArgs(directive.params)})`;
+      const methodArgs = this._emitMethodArgs(directive.params);
+      if (!methodArgs) {
+        return `@${directive.name}`;
+      }
+      return `@${directive.name}(${methodArgs})`;
     }).join(' ');
   }
 


### PR DESCRIPTION
### Issue
GraphQL directives may have a list of arguments wrapped by parenthesis. When there are no arguments, the directive should not have prenthesis after its name.
Currently ts2gql is printing parenthesis when there are no arguments.

### Action
Dont emit parenthesis when directive has no arguments.

### Example test
```ts
interface Query {
    /** @graphql Directives
     * @t1    
     * 
     * @t2 ()
     * @t3 (false: 0)
     * @t4 (     )
     * @t5 (
     * )
     */
    foo(bar: number): string
}

/** @graphql schema */
export interface Schema {
    query: Query
}
```
Should emit
```gql
type Query {
  foo(bar: Number!): String! @t1 @t2 @t3(false: 0) @t4 @t5
}

schema {
  query: Query
}
```
