### PR TITLE
Add support for nullable with question marks in argument lists

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -188,14 +188,7 @@ export default class Emitter {
   }
 
   _emitMethodArgs(node:Types.MethodParamsNode):string {
-    const resolvedArgs = _.mapValues(node.args, (param:Types.Node) => {
-      if (param.type === Types.NodeType.REFERENCE) {
-        return this.types[param.target];
-      }
-      return param;
-    });
-
-    return _.map(resolvedArgs, (argValue:Types.Node, argName:string) => {
+    return _.map(node.args, (argValue:Types.Node, argName:string) => {
       return `${this._name(argName)}: ${this._emitExpression(argValue)}`;
     }).join(', ');
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export enum NodeType {
 
 export interface InterfaceNode extends ComplexNode {
   type:NodeType.INTERFACE;
-  members:NamedNode[];
+  members:FieldNode[];
   inherits:SymbolName[];
   concrete?:boolean; // Whether the type is directly used (returned).
 }
@@ -152,7 +152,7 @@ export type Node =
   AnyNode |
   ValueNode;
 
-export type NamedNode = MethodNode | PropertyNode;
+export type FieldNode = MethodNode | PropertyNode;
 
 export type TypeMap = {[key:string]:Node};
 


### PR DESCRIPTION
This implements `?` support for argument lists. When a function parameter is tagged with the `?` mark it becomes nullable. For instance

```ts
interface A {
  a: boolean
}
interface B {
  b: boolean
}
type AB = A | B
interface Query {
  foo(a?: number, b?: B, ab?: AB): boolean
}
```
Becomes
```gql
type A {
  a: Boolean!
}
type B {
  b: Boolean!
}
union AB = A | B
type Query {
  foo(a: Float, b: B, ab: AB): Boolean!
}
```