### PR TITLE
New type collection architecture 

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -7,7 +7,6 @@ import * as util from './util';
 import { MethodParamsParser } from './Parser';
 
 const SyntaxKind = typescript.SyntaxKind;
-const TypeFlags = typescript.TypeFlags;
 
 export interface CollectorType {
   types:types.TypeDefinitionMap;

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -560,7 +560,11 @@ export class Collector implements CollectorType {
         throw new Error(`Cannot create alias for GraphQL Wrapping Types.`);
       }
       if (util.isBuiltInScalar(nonNullMember)) {
-        this._collectIntOrIDKind(nonNullMember, doc);
+        const intOrID = this._collectIntOrIDKind(nonNullMember, doc);
+        if (intOrID) {
+          throw new Error(`Can not define ${name} as ${intOrID}.`
+          + ` GraphQL BuiltIn Primitives can not be nullable by default.`);
+        }
         return {
           name,
           nullable,
@@ -649,15 +653,10 @@ export class Collector implements CollectorType {
   }
 
   _concrete(node:types.InterfaceTypeDefinitionNode):types.ObjectTypeDefinitionNode {
-    return {
-      documentation: node.documentation,
-      originalLine: node.originalLine,
-      originalColumn: node.originalColumn,
-      kind: types.GQLDefinitionKind.OBJECT_DEFINITION,
-      name: node.name,
-      implements: node.implements,
-      fields: node.fields,
-    };
+    const concrete = {} as types.ObjectTypeDefinitionNode;
+    Object.assign(concrete, node);
+    concrete.kind = types.GQLDefinitionKind.OBJECT_DEFINITION;
+    return concrete;
   }
 
   _directiveFromDocTag(jsDocTag:doctrine.Tag):types.DirectiveDefinitionNode {

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -354,7 +354,8 @@ export default class Collector {
     });
   }
 
-  _collectTypeAliasDeclaration(node:typescript.TypeAliasDeclaration):types.Node {
+  _collectTypeAliasDeclaration(node:typescript.TypeAliasDeclaration):types.ScalarTypeDefinitionNode |
+  types.UnionTypeDefinitionNode | types.EnumTypeDefinitionNode {
     // TODO : Deal with JSDoc
     return this._addTypeDefinition(node, () => ({
       type: types.GQLNodeKind.ALIAS,
@@ -487,7 +488,6 @@ export default class Collector {
     return symbol;
   }
 
-
   _concrete(node:types.InterfaceTypeDefinitionNode):types.ObjectTypeDefinitionNode {
     return {
       documentation: node.documentation,
@@ -500,10 +500,7 @@ export default class Collector {
   }
 
   _directiveFromDocTag(jsDocTag:doctrine.Tag):types.DirectiveDefinitionNode {
-    let directiveParams = {
-      kind: types.GQLNodeKind.ARGUMENTS_DEFINITION,
-      args: {},
-    } as types.DirectiveArguments;
+    let directiveParams = [] as types.DirectiveInputValueNode[];
     if (jsDocTag.description) {
       const parser = new MethodParamsParser();
       try {
@@ -516,7 +513,7 @@ export default class Collector {
     return {
       kind: types.GQLNodeKind.DIRECTIVE,
       name: jsDocTag.title,
-      arguments?: directiveParams,
+      args: directiveParams,
     };
   }
 }

--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -240,6 +240,11 @@ export class Collector implements CollectorType {
       return !ownFieldNames.has(inheritedField.name);
     }));
 
+    if (mergedFields.length === 0) {
+      const msg = `GraphQL does not allow Objects and Interfaces without fields.`;
+      throw new Error(`At interface '${name}'\n${msg}`);
+    }
+
     const collected = {
       documentation,
       name,
@@ -316,7 +321,7 @@ export class Collector implements CollectorType {
     if (!util.isInputType(collected)) {
       const kind = util.isWrappingType(collected) ? collected.wrapped.kind : collected.kind;
       const msg = `Argument lists accept only GraphQL Scalars, Enums and Input Object types. Got ${kind}.`;
-      throw new Error(`At parameter ${name}\n${msg}`);
+      throw new Error(`At parameter '${name}'\n${msg}`);
     }
     if (param.questionToken) {
       collected.nullable = true;
@@ -430,7 +435,7 @@ export class Collector implements CollectorType {
         } else if (util.extractTagDescription(doc, /^(ID)|(Id)|(id)$/)) {
           if (aliasType.kind !== types.GQLTypeKind.STRING_TYPE && aliasType.kind !== types.GQLTypeKind.FLOAT_TYPE) {
             const msg = `GraphQL ID is incompatible with type ${aliasType.kind}`;
-            throw new Error(`At TypeScript Alias ${name}\n${msg}`);
+            throw new Error(`At TypeScript Alias '${name}'\n${msg}`);
           }
           definition.builtIn = types.GQLTypeKind.ID_TYPE;
         }
@@ -446,7 +451,7 @@ export class Collector implements CollectorType {
         console.error(`On file ${node.getSourceFile().fileName}`);
         console.error(`Line ${node.getSourceFile().getStart()}`);
         const msg = `Unsupported alias for GraphQL type ${aliasType.kind}`;
-        throw new Error(`At TypeScript Alias ${name}\n${msg}`);
+        throw new Error(`At TypeScript Alias '${name}'\n${msg}`);
       }
     }
     return this._addTypeDefinition(definition);

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -37,7 +37,7 @@ export default class Emitter {
 
     if (node.type === Types.NodeType.ALIAS && node.target.type === Types.NodeType.REFERENCE) {
       const referencedNode = this.types[node.target.target];
-      if (util.isPrimitive(referencedNode) || referencedNode.type === Types.NodeType.ENUM) {
+      if (util.isBuiltInScalar(referencedNode) || referencedNode.type === Types.NodeType.ENUM) {
         this.renames[name] = node.target.target;
         return true;
       }
@@ -58,7 +58,7 @@ export default class Emitter {
   _emitAlias(node:Types.AliasNode, name:Types.SymbolName):string {
     const aliasTarget = node.target.type === Types.NodeType.NOT_NULL ? node.target.node : node.target;
 
-    if (util.isPrimitive(aliasTarget)) {
+    if (util.isBuiltInScalar(aliasTarget)) {
       return this._emitScalarDefinition(name);
     } else if (aliasTarget.type === Types.NodeType.REFERENCE) {
       return `union ${this._name(name)} = ${this._emitReference(aliasTarget)}`;
@@ -86,7 +86,7 @@ export default class Emitter {
       }, this._name(name));
     }
 
-    if (node.types.length === 1 && util.isPrimitive(node.types[0])) {
+    if (node.types.length === 1 && util.isBuiltInScalar(node.types[0])) {
       // Since union of scalars is forbidden, interpret as a custom Scalar declaration
       return this._emitScalarDefinition(name);
     }
@@ -108,7 +108,7 @@ export default class Emitter {
       firstChildType = util.unwrapNotNull(firstChildType.target);
     }
 
-    if (util.isPrimitive(firstChildType)) {
+    if (util.isBuiltInScalar(firstChildType)) {
       throw new Error('GraphQL does not support unions with GraphQL Scalars');
     } else if (firstChildType.type === Types.NodeType.UNION) {
       throw new Error('GraphQL does not support unions with GraphQL Unions');

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -10,6 +10,7 @@ export default class Emitter {
   private root:types.SchemaDefinitionNode;
   constructor(collector:CollectorType) {
     this.typeMap = collector.types;
+    // console.log(JSON.stringify([...this.typeMap], undefined, 1))
     if (!collector.root) {
       throw new Error(`Empty schema definition.`);
     }
@@ -110,10 +111,10 @@ export default class Emitter {
   }
 
   _emitArguments(args?:(types.InputValueDefinitionNode | types.DirectiveInputValueNode)[]):string {
-    return args ? `(${args.map(this._emitInputValue).join(', ')})` : '';
+    return args && args.length > 0 ? `(${args.map(this._emitInputValue).join(', ')})` : '';
   }
 
-  _emitInputValue(node:types.InputValueDefinitionNode | types.DirectiveInputValueNode):string {
+  _emitInputValue = (node:types.InputValueDefinitionNode | types.DirectiveInputValueNode):string => {
     return `${this._name(node.name)}: ${this._emitExpression(node.value)}`;
   }
 

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -50,7 +50,7 @@ export default class Emitter {
         content = this._emitScalarDefinition(node, name);
         break;
       case types.GQLDefinitionKind.DEFINITION_ALIAS:
-        const aliased = this.typeMap[node.target];
+        const aliased = this.typeMap.get(node.target)!;
         content = this.emitTopLevelNode(aliased, name, stream);
         break;
       default:

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -334,17 +334,4 @@ export default class Emitter {
     return _.uniq(interfaces);
   }
 
-  _hasDocTag(node:Types.ComplexNode, prefix:string):boolean {
-    return !!this._getDocTag(node, prefix);
-  }
-
-  _getDocTag(node:Types.ComplexNode, prefix:string):string|null {
-    if (!node.documentation) return null;
-    for (const tag of node.documentation.tags) {
-      if (tag.title !== 'graphql') continue;
-      if (tag.description.startsWith(prefix)) return tag.description;
-    }
-    return null;
-  }
-
 }

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -1,156 +1,119 @@
 import * as _ from 'lodash';
-import * as Types from './types';
+import * as types from './types';
 import * as util from './util';
+import { CollectorType } from './Collector';
 
 // tslint:disable-next-line
 // https://raw.githubusercontent.com/sogko/graphql-shorthand-notation-cheat-sheet/master/graphql-shorthand-notation-cheat-sheet.png
 export default class Emitter {
-  renames:{[key:string]:string} = {};
-
-  constructor(private types:Types.TypeMap) {
-    this.types = <Types.TypeMap>_.omitBy(types, (node, name) => this._preprocessNode(node, name!));
+  private typeMap:types.TypeDefinitionMap;
+  private root:types.SchemaDefinitionNode;
+  constructor(collector:CollectorType) {
+    this.typeMap = collector.types;
+    if (!collector.root) {
+      throw new Error(`Empty schema definition.`);
+    }
+    this.root = collector.root;
   }
 
   emitAll(stream:NodeJS.WritableStream) {
     stream.write('\n');
-    _.each(this.types, (node, name) => this.emitTopLevelNode(node, name!, stream));
+    this.typeMap.forEach((node, name) => {
+      const content = this.emitTopLevelNode(node, name, stream);
+      if (content) {
+        stream.write(`${content}\n\n`);
+      }
+    });
+
+    stream.write(`${this.emitSchema()}\n`);
   }
 
-  emitTopLevelNode(node:Types.Node, name:Types.SymbolName, stream:NodeJS.WritableStream) {
+  emitTopLevelNode(node:types.TypeDefinitionNode, name:types.SymbolName, stream:NodeJS.WritableStream):string {
     let content;
-    if (node.type === Types.NodeType.ALIAS) {
-      content = this._emitAlias(node, name);
-    } else if (node.type === Types.NodeType.INTERFACE) {
-      content = this._emitInterface(node, name);
-    } else if (node.type === Types.NodeType.ENUM) {
-      content = this._emitEnum(node, name);
-    } else {
-      throw new Error(`Don't know how to emit ${node.type} as a top level node`);
+    switch (node.kind) {
+      case types.GQLDefinitionKind.OBJECT_DEFINITION:
+        break;
+      case types.GQLDefinitionKind.INTERFACE_DEFINITION:
+        break;
+      case types.GQLDefinitionKind.INPUT_OBJECT_DEFINITION:
+        content = this._emitInputObject(node, name);
+        break;
+      case types.GQLDefinitionKind.ENUM_DEFINITION:
+        content = this._emitEnum(node, name);
+        break;
+      case types.GQLDefinitionKind.UNION_DEFINITION:
+        content = this._emitUnion(node, name);
+        break;
+      case types.GQLDefinitionKind.SCALAR_DEFINITION:
+        content = this._emitScalarDefinition(node, name);
+        break;
+      case types.GQLDefinitionKind.DEFINITION_ALIAS:
+        const aliased = this.typeMap[node.target];
+        content = this.emitTopLevelNode(aliased, name, stream);
     }
-    stream.write(`${content}\n\n`);
+    return content;
   }
 
-  // Preprocessing
-
-  _preprocessNode(node:Types.Node, name:Types.SymbolName):boolean {
-    const specialTags = ['ID', 'Int', 'Float'];
-
-    if (node.type === Types.NodeType.ALIAS && node.target.type === Types.NodeType.REFERENCE) {
-      const referencedNode = this.types[node.target.target];
-      if (util.isBuiltInScalar(referencedNode) || referencedNode.type === Types.NodeType.ENUM) {
-        this.renames[name] = node.target.target;
-        return true;
-      }
-    } else if (node.type === Types.NodeType.ALIAS) {
-      for (const tag of specialTags) {
-        if (this._hasDocTag(node, tag)) {
-          this.renames[name] = tag;
-          return true;
-        }
-      }
-    }
-
-    return false;
+  emitSchema() {
+    const properties = [
+      `query: ${this.root.query}`,
+      this.root.mutation ? `mutation: ${this.root.mutation}` : '',
+    ];
+    return `schema {\n${this._indent(properties)}\n}`;
   }
 
-  // Nodes
+  // Specialized emitters
 
-  _emitAlias(node:Types.AliasNode, name:Types.SymbolName):string {
-    const aliasTarget = node.target.type === Types.NodeType.NOT_NULL ? node.target.node : node.target;
-
-    if (util.isBuiltInScalar(aliasTarget)) {
-      return this._emitScalarDefinition(name);
-    } else if (aliasTarget.type === Types.NodeType.REFERENCE) {
-      return `union ${this._name(name)} = ${this._emitReference(aliasTarget)}`;
-    } else if (aliasTarget.type === Types.NodeType.UNION) {
-      return this._emitUnion(aliasTarget, name);
-    } else {
-      throw new Error(`Can't serialize ${JSON.stringify(aliasTarget, undefined, 1)} as an alias`);
-    }
+  _emitFields(fields:types.FieldDefinitionNode[]) {
+    const emitted = fields.map(field => this._emitField(field));
+    return this._indent(emitted);
   }
 
-  _emitScalarDefinition(name:Types.SymbolName):string {
-    return `scalar ${this._name(name)}`;
+  _emitField(field:types.FieldDefinitionNode) {
+    const argumentList = this._emitArguments(field.arguments);
+    const directives = this._emitFieldDirectives(field.directives);
+    return `${this._name(field.name)}${argumentList}: ${this._emitExpression(field.type)} ${directives}`;
   }
 
-  _emitReference(node:Types.ReferenceNode):string {
+  _emitArguments(args?:(types.InputValueDefinitionNode | types.DirectiveInputValueNode)[]):string {
+    return args ? `(${args.map(this._emitInputValue).join(', ')})` : '';
+  }
+
+  _emitInputValue(node:types.InputValueDefinitionNode | types.DirectiveInputValueNode):string {
+    return `${this._name(node.name)}: ${this._emitExpression(node.value)}`;
+  }
+
+  _emitFieldDirectives(directives?:types.DirectiveDefinitionNode[]):string {
+    return directives ? directives.map((directive:types.DirectiveDefinitionNode) => {
+      const emittedArgs = this._emitArguments(directive.args);
+      return `@${directive.name}${emittedArgs}`;
+    }).join(' ') : '';
+  }
+
+  _emitInputObject(node:types.InputObjectTypeDefinition, name:types.SymbolName):string {
+    return `input ${this._name(name)} {\n${this._emitFields(node.fields)}\n}`;
+  }
+
+  _emitEnum(node:types.EnumTypeDefinitionNode, name:types.SymbolName):string {
+    return `enum ${this._name(name)} {\n${this._indent(node.values)}\n}`;
+  }
+
+  _emitUnion(node:types.UnionTypeDefinitionNode, name:types.SymbolName):string {
+    const nodeNames = node.members.map(member => member.target);
+    return `union ${this._name(name)} = ${nodeNames.join(' | ')}`;
+  }
+
+  _emitScalarDefinition(node:types.ScalarTypeDefinitionNode, name:types.SymbolName):string {
+    return node.builtIn ? '' : `scalar ${this._name(name)}`;
+  }
+
+  _emitReference(node:types.ReferenceNode):string {
     return this._name(node.target);
   }
 
-  _emitUnion(node:Types.UnionNode, name:Types.SymbolName):string {
-    if (_.every(node.types, entry => entry.type === Types.NodeType.STRING_LITERAL)) {
-      const nodeValues = node.types.map((type:Types.StringLiteralNode) => type.value);
-      return this._emitEnum({
-        type: Types.NodeType.ENUM,
-        values: _.uniq(nodeValues),
-      }, this._name(name));
-    }
-
-    if (node.types.length === 1 && util.isBuiltInScalar(node.types[0])) {
-      // Since union of scalars is forbidden, interpret as a custom Scalar declaration
-      return this._emitScalarDefinition(name);
-    }
-
-    const unionNodeTypes = node.types.map((type) => {
-      if (type.type !== Types.NodeType.REFERENCE && (type.type !== Types.NodeType.NOT_NULL
-        || type.node.type !== Types.NodeType.REFERENCE )) {
-        const msg = 'GraphQL unions require that all types are references. Got a '
-        + (type.type === Types.NodeType.NOT_NULL ? type.node.type : type.type);
-        throw new Error(msg);
-
-      }
-      return (type.type === Types.NodeType.REFERENCE ? type : type.node as Types.ReferenceNode);
-    });
-
-    const firstChild = unionNodeTypes[0];
-    let firstChildType = this.types[firstChild.target];
-    if (firstChildType.type === Types.NodeType.ALIAS) {
-      firstChildType = util.unwrapNotNull(firstChildType.target);
-    }
-
-    if (util.isBuiltInScalar(firstChildType)) {
-      throw new Error('GraphQL does not support unions with GraphQL Scalars');
-    } else if (firstChildType.type === Types.NodeType.UNION) {
-      throw new Error('GraphQL does not support unions with GraphQL Unions');
-    } else if (firstChildType.type === Types.NodeType.INTERFACE && !firstChildType.concrete) {
-      throw new Error('GraphQL does not support unions with GraphQL Interfaces.');
-    } else if (firstChildType.type === Types.NodeType.ENUM) {
-      const nodeTypes = unionNodeTypes.map((type:Types.ReferenceNode) => {
-        const subNode = this.types[type.target];
-        if (subNode.type !== Types.NodeType.ENUM) {
-          throw new Error(`ts2gql expected a union of only enums since first child is an enum. Got a ${type.type}`);
-        }
-        return subNode.values;
-      });
-
-      return this._emitEnum({
-        type: Types.NodeType.ENUM,
-        values: _.uniq(_.flatten(nodeTypes)),
-      }, this._name(name));
-
-    } else if (firstChildType.type === Types.NodeType.INTERFACE) {
-      const nodeNames = unionNodeTypes.map((type:Types.ReferenceNode) => {
-
-        const subNode = this.types[type.target];
-        if (subNode.type !== Types.NodeType.INTERFACE) {
-          let error = 'GraphQL expects an union of only Object Types.';
-          if (subNode.type === Types.NodeType.ALIAS) {
-            const target = util.unwrapNotNull(subNode.target);
-            error = error + ` Got a ${target.type}.`;
-          }
-          throw new Error(error);
-        }
-        return type.target;
-      });
-      return `union ${this._name(name)} = ${nodeNames.join(' | ')}`;
-    } else {
-      throw new Error(`ts2gql currently does not support unions for type: ${firstChildType.type}`);
-    }
-  }
-
-  _emitInterface(node:Types.InterfaceNode, name:Types.SymbolName):string {
+  _emitInterface(node:types.InterfaceNode, name:types.SymbolName):string {
     // GraphQL expects denormalized type interfaces
-    const members = <Types.Node[]>_(this._transitiveInterfaces(node))
+    const members = <types.Node[]>_(this._transitiveInterfaces(node))
       .map(i => i.members)
       .flatten()
       .uniqBy('name')
@@ -161,9 +124,9 @@ export default class Emitter {
     // to remove all references (complicated).
     if (!members.length) {
       members.push({
-        type: Types.NodeType.PROPERTY,
+        type: types.GQLTypeKind.PROPERTY,
         name: '__placeholder',
-        signature: {type: Types.NodeType.BOOLEAN},
+        signature: {type: types.GQLTypeKind.BOOLEAN},
       });
     }
 
@@ -172,100 +135,55 @@ export default class Emitter {
       return this._emitSchemaDefinition(members);
     }
 
-    const properties = _.map(members, (member) => {
-      if (member.type === Types.NodeType.METHOD) {
-        return this._emitInterfaceMethod(member);
-      } else if (member.type === Types.NodeType.PROPERTY) {
-        return `${this._name(member.name)}: ${this._emitExpression(member.signature)}`;
-      } else {
-        throw new Error(`Can't serialize ${member.type} as a property of an interface`);
-      }
-    });
-
-    if (this._getDocTag(node, 'input')) {
-      return `input ${this._name(name)} {\n${this._indent(properties)}\n}`;
-    }
-
     if (node.concrete) {
       return `type ${this._name(name)} {\n${this._indent(properties)}\n}`;
     }
 
     let result = `interface ${this._name(name)} {\n${this._indent(properties)}\n}`;
-    const fragmentDeclaration = this._getDocTag(node, 'fragment');
-    if (fragmentDeclaration) {
-      result = `${result}\n\n${fragmentDeclaration} {\n${this._indent(members.map((m:any) => m.name))}\n}`;
-    }
 
     return result;
   }
 
-  _emitInterfaceMethod(member:Types.MethodNode):string {
-    const parameters = `(${this._emitMethodArgs(member.parameters)})`;
-    const returnType = this._emitExpression(member.returns);
-    const methodDirectives = this._emitMethodDirectives(member.directives);
-    return `${this._name(member.name)}${parameters}: ${returnType} ${methodDirectives}`;
-  }
-
-  _emitMethodArgs(node:Types.MethodParamsNode):string {
-    return _.map(node.args, (argValue:Types.Node, argName:string) => {
-      return `${this._name(argName)}: ${this._emitExpression(argValue)}`;
-    }).join(', ');
-  }
-
-  _emitMethodDirectives(directives:Types.DirectiveNode[]):string {
-    return _.map(directives, (directive:Types.DirectiveNode) => {
-      const methodArgs = this._emitMethodArgs(directive.params);
-      if (!methodArgs) {
-        return `@${directive.name}`;
-      }
-      return `@${directive.name}(${methodArgs})`;
-    }).join(' ');
-  }
-
-  _emitEnum(node:Types.EnumNode, name:Types.SymbolName):string {
-    return `enum ${this._name(name)} {\n${this._indent(node.values)}\n}`;
-  }
-
-  _emitExpression = (node:Types.Node):string => {
+  _emitExpression = (node:types.Node):string => {
     if (!node) {
       return '';
-    } else if (node.type === Types.NodeType.VALUE) {
+    } else if (node.kind === types.GQLTypeKind.VALUE) {
       return `${node.value}`;
-    } else if (node.type === Types.NodeType.NOT_NULL) {
+    } else if (node.kind === types.GQLTypeKind.NOT_NULL) {
       return `${this._emitExpression(node.node)}!`;
-    } else if (node.type === Types.NodeType.STRING) {
+    } else if (node.kind === types.GQLTypeKind.STRING) {
       return 'String'; // TODO: ID annotation
-    } else if (node.type === Types.NodeType.NUMBER) {
+    } else if (node.kind === types.GQLTypeKind.NUMBER) {
       return 'Float'; // TODO: Int/Float annotation
-    } else if (node.type === Types.NodeType.BOOLEAN) {
+    } else if (node.kind === types.GQLTypeKind.BOOLEAN) {
       return 'Boolean';
-    } else if (node.type === Types.NodeType.REFERENCE) {
+    } else if (node.kind === types.GQLTypeKind.REFERENCE) {
       return this._name(node.target);
-    } else if (node.type === Types.NodeType.ARRAY) {
+    } else if (node.kind === types.GQLTypeKind.ARRAY) {
       return `[${node.elements.map(this._emitExpression).join(' | ')}]`;
-    } else if (node.type === Types.NodeType.LITERAL_OBJECT || node.type === Types.NodeType.INTERFACE) {
+    } else if (node.kind === types.GQLTypeKind.LITERAL_OBJECT || node.kind === types.GQLTypeKind.INTERFACE) {
       return _(this._collectMembers(node))
-        .map((member:Types.PropertyNode) => {
+        .map((member:types.PropertyNode) => {
           return `${this._name(member.name)}: ${this._emitExpression(member.signature)}`;
         })
         .join(', ');
-    } else if (node.type === Types.NodeType.UNION) {
-      if (node.types.length !== 1) {
+    } else if (node.kind === types.GQLTypeKind.UNION) {
+      if (node.members.length !== 1) {
         throw new Error(`There's no support for inline union with non-null and non-undefined types.`);
       }
-      return this._emitExpression(node.types[0]);
+      return this._emitExpression(node.members[0]);
     } else {
-      throw new Error(`Can't serialize ${node.type} as an expression`);
+      throw new Error(`Can't serialize ${node.kind} as an expression`);
     }
   }
 
-  _collectMembers = (node:Types.InterfaceNode|Types.LiteralObjectNode):Types.PropertyNode[] => {
-    let members:Types.Node[] = [];
-    if (node.type === Types.NodeType.LITERAL_OBJECT) {
+  _collectMembers = (node:types.InterfaceNode|types.LiteralObjectNode):types.PropertyNode[] => {
+    let members:types.Node[] = [];
+    if (node.kind === types.GQLTypeKind.LITERAL_OBJECT) {
       members = node.members;
     } else {
-      const seenProps = new Set<Types.SymbolName>();
-      let interfaceNode:Types.InterfaceNode|null;
+      const seenProps = new Set<types.SymbolName>();
+      let interfaceNode:types.InterfaceNode|null;
       interfaceNode = node;
 
       // loop through this interface and any super-interfaces
@@ -278,8 +196,8 @@ export default class Emitter {
         if (interfaceNode.inherits.length > 1) {
           throw new Error(`No support for multiple inheritence: ${JSON.stringify(interfaceNode.inherits)}`);
         } else if (interfaceNode.inherits.length === 1) {
-          const supertype:Types.Node = this.types[interfaceNode.inherits[0]];
-          if (supertype.type !== Types.NodeType.INTERFACE) {
+          const supertype:types.Node = this.typeMap[interfaceNode.inherits[0]];
+          if (supertype.kind !== types.GQLTypeKind.INTERFACE) {
             throw new Error(`Expected supertype to be an interface node: ${supertype}`);
           }
           interfaceNode = supertype;
@@ -290,33 +208,16 @@ export default class Emitter {
     }
 
     for (const member of members) {
-      if (member.type !== Types.NodeType.PROPERTY) {
-        throw new Error(`Expected members to be properties; got ${member.type}`);
+      if (member.kind !== types.GQLTypeKind.PROPERTY) {
+        throw new Error(`Expected members to be properties; got ${member.kind}`);
       }
     }
-    return members as Types.PropertyNode[];
-  }
-
-  _emitSchemaDefinition(members:Types.Node[]):string {
-    const properties = _.map(members, (member) => {
-      if (member.type !== Types.NodeType.PROPERTY) {
-        throw new Error(`Can't serialize ${member.type} as a property of an schema definition`);
-      }
-      const propertySignature = member.signature;
-        // Properties of the schema declaration should not contain ! marks
-        if (propertySignature.type === Types.NodeType.NOT_NULL) {
-          member.signature = propertySignature.node;
-        }
-        return `${this._name(member.name)}: ${this._emitExpression(member.signature)}`;
-    });
-
-    return `schema {\n${this._indent(properties)}\n}`;
+    return members as types.PropertyNode[];
   }
 
   // Utility
 
-  _name = (name:Types.SymbolName):string => {
-    name = this.renames[name] || name;
+  _name = (name:types.SymbolName):string => {
     return name.replace(/\W/g, '_');
   }
 
@@ -325,10 +226,10 @@ export default class Emitter {
     return content.map(s => `  ${s}`).join('\n');
   }
 
-  _transitiveInterfaces(node:Types.InterfaceNode):Types.InterfaceNode[] {
+  _transitiveInterfaces(node:types.InterfaceNode):types.InterfaceNode[] {
     let interfaces = [node];
     for (const name of node.inherits) {
-      const inherited = <Types.InterfaceNode>this.types[name];
+      const inherited = <types.InterfaceNode>this.typeMap[name];
       interfaces = interfaces.concat(this._transitiveInterfaces(inherited));
     }
     return _.uniq(interfaces);

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -55,9 +55,9 @@ export class MethodParamsParser  {
         }
         this.args[nameToken.value] = {
             name: nameToken.value,
-            kind: types.GQLNodeKind.DIRECTIVE_INPUT_VALUE_DEFINITION,
+            kind: types.GQLDefinitionKind.DIRECTIVE_INPUT_VALUE_DEFINITION,
             value: {
-                kind: types.GQLNodeKind.VALUE,
+                kind: types.GQLTypeKind.VALUE,
                 value: valueToken.value,
             },
         };

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -18,7 +18,7 @@ export class ParsingFailedException extends Error {}
 export class MethodParamsParser  {
     private tokenizer:MethodParamsTokenizer;
     private tokens:MethodParamsToken[];
-    private args:types.TypeMap;
+    private args:types.TypeDefinitionMap;
 
     constructor() {
         this.tokenizer = new MethodParamsTokenizer();
@@ -26,15 +26,15 @@ export class MethodParamsParser  {
         this.args = {};
     }
 
-    parse(stringToParse:string):types.MethodParamsNode {
+    parse(stringToParse:string):types.DirectiveArguments {
         this.tokens = this.tokenizer.tokenize(stringToParse);
         return {
-            type: types.NodeType.METHOD_PARAMS,
+            kind: types.GQLNodeKind.ARGUMENTS_DEFINITION,
             args: this._parseArgs(),
         };
     }
 
-    _parseArgs():types.TypeMap {
+    _parseArgs():types.TypeDefinitionMap {
         if (!this.tokens || this.tokens[0].type !== TokenType.PARAMETER_LIST_BEGIN) {
             throw new ParsingFailedException(`Token list created without beginning token.`);
         }
@@ -68,7 +68,7 @@ export class MethodParamsParser  {
             throw new ParsingFailedException(`Repeated param name ${nameToken.value}.`);
         }
         this.args[nameToken.value] = {
-            type: types.NodeType.VALUE,
+            kind: types.GQLNodeKind.VALUE,
             value: valueToken.value,
         };
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,40 +1,26 @@
 import * as types from './types';
 import { MethodParamsTokenizer, MethodParamsToken, TokenType } from './Tokenizer';
 
-export interface PartialParseResult {
-    nextIdx:number;
-}
-
-export interface ArgNameParseResult extends PartialParseResult {
-    argName:string;
-}
-
-export interface ArgValueParseResult extends PartialParseResult {
-    argValue:types.ValueNode;
-}
-
-export class ParsingFailedException extends Error {}
+class ParsingFailedException extends Error {}
 
 export class MethodParamsParser  {
     private tokenizer:MethodParamsTokenizer;
     private tokens:MethodParamsToken[];
-    private args:types.TypeDefinitionMap;
+    private args:Map<string, types.DirectiveInputValueNode>;
 
     constructor() {
         this.tokenizer = new MethodParamsTokenizer();
         this.tokens = [];
-        this.args = {};
+        this.args = {} as Map<string, types.DirectiveInputValueNode>;
     }
 
-    parse(stringToParse:string):types.DirectiveArguments {
+    parse(stringToParse:string):types.DirectiveInputValueNode[] {
         this.tokens = this.tokenizer.tokenize(stringToParse);
-        return {
-            kind: types.GQLNodeKind.ARGUMENTS_DEFINITION,
-            args: this._parseArgs(),
-        };
+        this._parseArgs();
+        return Array.from(this.args.values());
     }
 
-    _parseArgs():types.TypeDefinitionMap {
+    _parseArgs():Map<string, types.DirectiveInputValueNode> {
         if (!this.tokens || this.tokens[0].type !== TokenType.PARAMETER_LIST_BEGIN) {
             throw new ParsingFailedException(`Token list created without beginning token.`);
         }
@@ -68,8 +54,12 @@ export class MethodParamsParser  {
             throw new ParsingFailedException(`Repeated param name ${nameToken.value}.`);
         }
         this.args[nameToken.value] = {
-            kind: types.GQLNodeKind.VALUE,
-            value: valueToken.value,
+            name: nameToken.value,
+            kind: types.GQLNodeKind.DIRECTIVE_INPUT_VALUE_DEFINITION,
+            value: {
+                kind: types.GQLNodeKind.VALUE,
+                value: valueToken.value,
+            },
         };
 
         return start + 3;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as doctrine from 'doctrine';
 import * as _ from 'lodash';
 import * as typescript from 'typescript';
 import * as path from 'path';
@@ -20,7 +21,10 @@ export function load(schemaRootPath:string, rootNodeNames:string[]):types.TypeDe
       interfaces[interfaceNode.name.text] = interfaceNode;
 
       const documentation = util.documentationForNode(interfaceNode, schemaRoot.text);
-      if (documentation && _.find(documentation.tags, {title: 'graphql', description: 'schema'})) {
+      const isSchemaRoot = documentation && _.find(documentation.tags, (tag:doctrine.Tag) => {
+        return tag.title === 'graphql' && /^[Ss]chema$/.test(tag.description);
+      });
+      if (isSchemaRoot) {
         rootNodeNames.push(interfaceNode.name.text);
       }
     }
@@ -40,7 +44,9 @@ export function load(schemaRootPath:string, rootNodeNames:string[]):types.TypeDe
   _.each(interfaces, (node, name) => {
     const documentation = util.documentationForNode(node);
     if (!documentation) return;
-    const override = _.find(documentation.tags, t => t.title === 'graphql' && t.description.startsWith('override'));
+    const override = _.find(documentation.tags, (tag:doctrine.Tag) => {
+      return tag.title === 'graphql' && /^[Oo]verride$/.test(tag.description);
+    });
     if (!override) return;
     const overrideName = override.description.split(' ')[1] || name!;
     collector.mergeOverrides(node, overrideName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,9 @@ export function load(schemaRootPath:string, rootNodeNames:string[]):CollectorTyp
   });
 
   rootNodeNames = _.uniq(rootNodeNames);
+  if (rootNodeNames.length === 0) {
+    throw new Error(`GraphQL Schema declaration not found`);
+  }
 
   const collector = new Collector(program);
   for (const name of rootNodeNames) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import * as util from './util';
 import Collector from './Collector';
 import Emitter from './Emitter';
 
-export function load(schemaRootPath:string, rootNodeNames:string[]):types.TypeMap {
+export function load(schemaRootPath:string, rootNodeNames:string[]):types.TypeDefinitionMap {
   schemaRootPath = path.resolve(schemaRootPath);
   const program = typescript.createProgram([schemaRootPath], {});
   const schemaRoot = program.getSourceFile(schemaRootPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,11 @@ import * as _ from 'lodash';
 import * as typescript from 'typescript';
 import * as path from 'path';
 
-import * as types from './types';
 import * as util from './util';
-import Collector from './Collector';
+import { Collector, CollectorType } from './Collector';
 import Emitter from './Emitter';
 
-export function load(schemaRootPath:string, rootNodeNames:string[]):types.TypeDefinitionMap {
+export function load(schemaRootPath:string, rootNodeNames:string[]):CollectorType {
   schemaRootPath = path.resolve(schemaRootPath);
   const program = typescript.createProgram([schemaRootPath], {});
   const schemaRoot = program.getSourceFile(schemaRootPath);
@@ -52,7 +51,7 @@ export function load(schemaRootPath:string, rootNodeNames:string[]):types.TypeDe
     collector.mergeOverrides(node, overrideName);
   });
 
-  return collector.types;
+  return collector;
 }
 
 export function emit(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import { NamedInputTypeNode, FieldDefinitionNode } from './types';
 import * as doctrine from 'doctrine';
 import { MethodParamsParser } from './Parser';
 
@@ -13,11 +12,7 @@ export interface TranspiledNode {
   originalColumn?:number;
 }
 
-export interface GraphQLNode extends TranspiledNode {
-  kind:GQLNodeKind;
-}
-
-export enum GQLNodeKind {
+export enum GQLDefinitionKind {
   // Definitions
   OBJECT_DEFINITION = 'object definition',
   INTERFACE_DEFINITION = 'interface definition',
@@ -26,11 +21,14 @@ export enum GQLNodeKind {
   UNION_DEFINITION = 'union definition',
   SCALAR_DEFINITION = 'scalar definition',
   FIELD_DEFINITION = 'field definition',
-  ARGUMENTS_DEFINITION = 'arguments definition',
   INPUT_VALUE_DEFINITION = 'input value definition',
+  DEFINITION_ALIAS = 'definition alias',
   // Directives
   DIRECTIVE = 'directive',
   DIRECTIVE_INPUT_VALUE_DEFINITION = 'directive input value definition',
+}
+
+export enum GQLTypeKind {
   // Wrapping Types
   LIST_TYPE = 'list',
   // Types
@@ -54,21 +52,22 @@ export enum GQLNodeKind {
 //
 // Abstractions
 //
-interface NamedNode extends GraphQLNode {
+interface NamedNode {
   name:SymbolName;
 }
 
-interface NullableNode extends GraphQLNode {
+interface NullableNode {
   nullable:boolean;
 }
+
 interface ReferenceNode extends NullableNode {
-  definitionTarget:SymbolName;
+  target:SymbolName;
 }
 
 //
 // Root node
 //
-export interface SchemaDefinitionNode extends GraphQLNode {
+export interface SchemaDefinitionNode extends TranspiledNode {
   query:ObjectTypeDefinitionNode;
   mutation?:ObjectTypeDefinitionNode;
 }
@@ -76,37 +75,46 @@ export interface SchemaDefinitionNode extends GraphQLNode {
 //
 // Type Definitions
 //
-export interface ObjectTypeDefinitionNode extends NamedNode {
-  kind:GQLNodeKind.OBJECT_DEFINITION;
+interface GraphQLDefinitionNode extends TranspiledNode, NamedNode {
+  kind:GQLDefinitionKind;
+}
+
+export interface ObjectTypeDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.OBJECT_DEFINITION;
   fields:OutputFieldDefinitionNode[];
 }
 
-export interface InterfaceTypeDefinitionNode extends NamedNode {
-  kind:GQLNodeKind.INTERFACE_DEFINITION;
+export interface InterfaceTypeDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.INTERFACE_DEFINITION;
   fields:OutputFieldDefinitionNode[];
 }
 
-export interface EnumTypeDefinitionNode extends NamedNode {
-  kind:GQLNodeKind.ENUM_DEFINITION;
+export interface EnumTypeDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.ENUM_DEFINITION;
   values:string[];
 }
 
-export interface InputObjectTypeDefinition extends NamedNode {
-  kind:GQLNodeKind.INPUT_OBJECT_DEFINITION;
+export interface InputObjectTypeDefinition extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.INPUT_OBJECT_DEFINITION;
   fields:InputFieldDefinitionNode[];
 }
 
-export interface UnionTypeDefinitionNode extends NamedNode, NullableNode {
-  kind:GQLNodeKind.UNION_DEFINITION;
+export interface UnionTypeDefinitionNode extends GraphQLDefinitionNode, NullableNode {
+  kind:GQLDefinitionKind.UNION_DEFINITION;
   members:ObjectTypeNode[];
 }
 
-export interface ScalarTypeDefinitionNode extends NamedNode {
-  kind:GQLNodeKind.SCALAR_DEFINITION;
+export interface ScalarTypeDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.SCALAR_DEFINITION;
+  builtIn?:GQLTypeKind.INT_TYPE|GQLTypeKind.ID_TYPE;
+}
+
+export interface DefinitionAliasNode extends GraphQLDefinitionNode, NullableNode, ReferenceNode {
+  kind:GQLDefinitionKind.DEFINITION_ALIAS;
 }
 
 export type TypeDefinitionNode = ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode | EnumTypeDefinitionNode |
-InputObjectTypeDefinition | UnionTypeDefinitionNode | ScalarTypeDefinitionNode;
+InputObjectTypeDefinition | UnionTypeDefinitionNode | ScalarTypeDefinitionNode | DefinitionAliasNode;
 
 export type TypeDefinitionMap = {[key:string]:TypeDefinitionNode};
 
@@ -114,11 +122,11 @@ export type TypeDefinitionMap = {[key:string]:TypeDefinitionNode};
 // Other Definitions
 //
 
-export interface FieldDefinitionNode extends NamedNode {
-  kind:GQLNodeKind.FIELD_DEFINITION;
+export interface FieldDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.FIELD_DEFINITION;
   category:GQLTypeCategory;
   type:OutputTypeNode;
-  arguments?:ArgumentsDefinitionNode;
+  arguments?:InputValueDefinitionNode[];
   directives?:DirectiveDefinitionNode[];
 }
 
@@ -130,23 +138,18 @@ export interface OutputFieldDefinitionNode extends FieldDefinitionNode {
   category:GQLTypeCategory.OUTPUT;
 }
 
-export interface ArgumentsDefinitionNode extends GraphQLNode {
-  kind:GQLNodeKind.ARGUMENTS_DEFINITION;
-  args:InputValueDefinitionNode[];
-}
-
-export interface InputValueDefinitionNode extends NamedNode {
-  kind:GQLNodeKind.INPUT_VALUE_DEFINITION;
+export interface InputValueDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.INPUT_VALUE_DEFINITION;
   value:InputTypeNode;
 }
 
-export interface DirectiveDefinitionNode extends NamedNode {
-  kind:GQLNodeKind.DIRECTIVE;
+export interface DirectiveDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.DIRECTIVE;
   args:DirectiveInputValueNode[];
 }
 
-export interface DirectiveInputValueNode extends NamedNode {
-  kind:GQLNodeKind.DIRECTIVE_INPUT_VALUE_DEFINITION;
+export interface DirectiveInputValueNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.DIRECTIVE_INPUT_VALUE_DEFINITION;
   value:ValueNode;
 }
 
@@ -155,6 +158,10 @@ export interface DirectiveInputValueNode extends NamedNode {
 //
 
 // General definitions
+
+interface GraphQLTypeNode extends TranspiledNode {
+  kind:GQLTypeKind;
+}
 
 export enum GQLTypeCategory {
   INPUT = 'input',
@@ -175,12 +182,12 @@ export type TypeNode = NamedTypeNode | WrappingTypeNode;
 
 // Wrapping Types
 
-interface WrappingNode<T extends GraphQLNode> extends NullableNode {
+interface WrappingNode<T extends GraphQLTypeNode | ReferenceNode> extends GraphQLTypeNode, NullableNode {
   wrapped:T;
 }
 
-export interface ListNode<T extends NamedTypeNode> extends WrappingNode<T | ListNode<T>> {
-  kind:GQLNodeKind.LIST_TYPE;
+export interface ListNode<T extends GraphQLTypeNode & NullableNode> extends WrappingNode<T | ListNode<T>> {
+  kind:GQLTypeKind.LIST_TYPE;
 }
 
 export type ListInputTypeNode = ListNode<NamedInputTypeNode>;
@@ -193,67 +200,67 @@ export type ReferenceTypeNode = ObjectTypeNode | InterfaceTypeNode | EnumTypeNod
 | CustomScalarTypeNode;
 
 export const DefinitionFromType = {
-  [GQLNodeKind.OBJECT_DEFINITION]:GQLNodeKind.OBJECT_TYPE,
-  [GQLNodeKind.ENUM_DEFINITION]:GQLNodeKind.ENUM_TYPE,
-  [GQLNodeKind.INPUT_OBJECT_DEFINITION]:GQLNodeKind.INPUT_OBJECT_TYPE,
-  [GQLNodeKind.UNION_DEFINITION]:GQLNodeKind.UNION_TYPE,
-  [GQLNodeKind.SCALAR_DEFINITION]:GQLNodeKind.CUSTOM_SCALAR_TYPE,
+  [GQLDefinitionKind.OBJECT_DEFINITION]:GQLTypeKind.OBJECT_TYPE,
+  [GQLDefinitionKind.ENUM_DEFINITION]:GQLTypeKind.ENUM_TYPE,
+  [GQLDefinitionKind.INPUT_OBJECT_DEFINITION]:GQLTypeKind.INPUT_OBJECT_TYPE,
+  [GQLDefinitionKind.UNION_DEFINITION]:GQLTypeKind.UNION_TYPE,
+  [GQLDefinitionKind.SCALAR_DEFINITION]:GQLTypeKind.CUSTOM_SCALAR_TYPE,
 };
 
-export interface ObjectTypeNode extends ReferenceNode {
-  kind:GQLNodeKind.OBJECT_TYPE;
+export interface ObjectTypeNode extends GraphQLTypeNode, ReferenceNode {
+  kind:GQLTypeKind.OBJECT_TYPE;
 }
 
-export interface InterfaceTypeNode extends ReferenceNode {
-  kind:GQLNodeKind.INTERFACE_TYPE;
+export interface InterfaceTypeNode extends GraphQLTypeNode, ReferenceNode {
+  kind:GQLTypeKind.INTERFACE_TYPE;
 }
 
-export interface EnumTypeNode extends ReferenceNode {
-  kind:GQLNodeKind.ENUM_TYPE;
+export interface EnumTypeNode extends GraphQLTypeNode, ReferenceNode {
+  kind:GQLTypeKind.ENUM_TYPE;
 }
 
-export interface InputObjectTypeNode extends ReferenceNode {
-  kind:GQLNodeKind.INPUT_OBJECT_TYPE;
+export interface InputObjectTypeNode extends GraphQLTypeNode, ReferenceNode {
+  kind:GQLTypeKind.INPUT_OBJECT_TYPE;
 }
 
-export interface UnionTypeNode extends ReferenceNode {
-  kind:GQLNodeKind.UNION_TYPE;
+export interface UnionTypeNode extends GraphQLTypeNode, ReferenceNode {
+  kind:GQLTypeKind.UNION_TYPE;
 }
 
 // Scalar Types
 
-export interface CustomScalarTypeNode extends ReferenceNode {
-  kind:GQLNodeKind.CUSTOM_SCALAR_TYPE;
+export interface CustomScalarTypeNode extends GraphQLTypeNode, ReferenceNode {
+  kind:GQLTypeKind.CUSTOM_SCALAR_TYPE;
 }
 
-export interface StringTypeNode extends NullableNode {
-  kind:GQLNodeKind.STRING_TYPE;
+export interface StringTypeNode extends GraphQLTypeNode, NullableNode {
+  kind:GQLTypeKind.STRING_TYPE;
 }
 
-export interface IntTypeNode extends NullableNode {
-  kind:GQLNodeKind.INT_TYPE;
+export interface IntTypeNode extends GraphQLTypeNode, NullableNode {
+  kind:GQLTypeKind.INT_TYPE;
 }
 
-export interface FloatTypeNode extends NullableNode {
-  kind:GQLNodeKind.FLOAT_TYPE;
+export interface FloatTypeNode extends GraphQLTypeNode, NullableNode {
+  kind:GQLTypeKind.FLOAT_TYPE;
 }
 
 type NumberTypeNode = IntTypeNode | FloatTypeNode;
 
-export interface BooleanTypeNode extends NullableNode {
-  kind:GQLNodeKind.BOOLEAN_TYPE;
+export interface BooleanTypeNode extends GraphQLTypeNode, NullableNode {
+  kind:GQLTypeKind.BOOLEAN_TYPE;
 }
 
-export interface IDTypeNode extends NullableNode {
-  kind:GQLNodeKind.ID_TYPE;
+export interface IDTypeNode extends GraphQLTypeNode, NullableNode {
+  kind:GQLTypeKind.ID_TYPE;
 }
 
 export type BuiltInScalarTypeNode = StringTypeNode | NumberTypeNode | BooleanTypeNode | IDTypeNode;
 export type ScalarTypeNode = CustomScalarTypeNode | BuiltInScalarTypeNode;
 
 // Currently we have no distinction between values: they're string-represented
-export interface ValueNode extends GraphQLNode {
-  kind:GQLNodeKind.VALUE;
+export interface ValueNode extends GraphQLTypeNode {
+  kind:GQLTypeKind.VALUE;
   value:string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,17 +128,19 @@ export type TypeDefinitionMap = Map<string, TypeDefinitionNode>;
 export interface FieldDefinitionNode extends GraphQLDefinitionNode {
   kind:GQLDefinitionKind.FIELD_DEFINITION;
   category:GQLTypeCategory;
-  type:OutputTypeNode;
+  type:InputTypeNode | OutputTypeNode;
   arguments?:InputValueDefinitionNode[];
   directives?:DirectiveDefinitionNode[];
 }
 
 export interface InputFieldDefinitionNode extends FieldDefinitionNode {
   category:GQLTypeCategory.INPUT;
+  type:InputTypeNode;
 }
 
 export interface OutputFieldDefinitionNode extends FieldDefinitionNode {
   category:GQLTypeCategory.OUTPUT;
+  type:OutputTypeNode;
 }
 
 export interface InputValueDefinitionNode extends GraphQLDefinitionNode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,6 @@ export enum GQLNodeKind {
   DIRECTIVE = 'directive',
   DIRECTIVE_INPUT_VALUE_DEFINITION = 'directive input value definition',
   // Wrapping Types
-  NON_NULL_TYPE = 'non null',
   LIST_TYPE = 'list',
   // Types
   REFERENCE = 'reference',
@@ -55,8 +54,15 @@ export enum GQLNodeKind {
 //
 // Abstractions
 //
-export interface NamedNode extends GraphQLNode {
+interface NamedNode extends GraphQLNode {
   name:SymbolName;
+}
+
+interface NullableNode extends GraphQLNode {
+  nullable:boolean;
+}
+interface ReferenceNode extends NullableNode {
+  definitionTarget:SymbolName;
 }
 
 //
@@ -90,7 +96,7 @@ export interface InputObjectTypeDefinition extends NamedNode {
   fields:InputFieldDefinitionNode[];
 }
 
-export interface UnionTypeDefinitionNode extends NamedNode {
+export interface UnionTypeDefinitionNode extends NamedNode, NullableNode {
   kind:GQLNodeKind.UNION_DEFINITION;
   members:ObjectTypeNode[];
 }
@@ -159,40 +165,32 @@ export type NamedInputTypeNode = ScalarTypeNode | EnumTypeNode | InputObjectType
 export type NamedOutputTypeNode = ScalarTypeNode | ObjectTypeNode | InterfaceTypeNode | UnionTypeNode | EnumTypeNode;
 type NamedTypeNode = NamedInputTypeNode | NamedOutputTypeNode;
 
-export type WrappingInputTypeNode = NonNullInputTypeNode | ListInputTypeNode;
-export type WrappingOutputTypeNode = NonNullOutputTypeNode | ListOutputTypeNode;
-export type WrappingTypeNode = WrappingInputTypeNode | WrappingOutputTypeNode;
+export type WrappingInputTypeNode = ListInputTypeNode;
+export type WrappingOutputTypeNode = ListOutputTypeNode;
+export type WrappingTypeNode = ListInputTypeNode | ListOutputTypeNode | ListTypeNode;
 
 export type InputTypeNode = NamedInputTypeNode | WrappingInputTypeNode;
 export type OutputTypeNode = NamedOutputTypeNode | WrappingOutputTypeNode;
-export type TypeNode = InputTypeNode | OutputTypeNode;
+export type TypeNode = NamedTypeNode | WrappingTypeNode;
 
 // Wrapping Types
 
-interface WrappingNode<T extends GraphQLNode> extends GraphQLNode {
+interface WrappingNode<T extends GraphQLNode> extends NullableNode {
   wrapped:T;
 }
 
-export interface NonNullTypeNode<T extends NamedTypeNode> extends WrappingNode<T | ListNode<T>> {
-  kind:GQLNodeKind.NON_NULL_TYPE;
-}
-
-export type NonNullInputTypeNode = NonNullTypeNode<NamedInputTypeNode>;
-export type NonNullOutputTypeNode = NonNullTypeNode<NamedOutputTypeNode>;
-
-interface ListNode<T extends NamedTypeNode> extends WrappingNode<T | NonNullTypeNode<T> | ListNode<T>> {
+export interface ListNode<T extends NamedTypeNode> extends WrappingNode<T | ListNode<T>> {
   kind:GQLNodeKind.LIST_TYPE;
 }
 
-type ListInputTypeNode = ListNode<NamedInputTypeNode>;
-type ListOutputTypeNode = ListNode<NamedOutputTypeNode>;
-export type ListTypeNode = ListInputTypeNode | ListOutputTypeNode;
+export type ListInputTypeNode = ListNode<NamedInputTypeNode>;
+export type ListOutputTypeNode = ListNode<NamedOutputTypeNode>;
+export type ListTypeNode = ListNode<NamedTypeNode>;
 
 // Named Types
 
-export interface ReferenceTypeNode extends GraphQLNode {
-  definitionTarget:SymbolName;
-}
+export type ReferenceTypeNode = ObjectTypeNode | InterfaceTypeNode | EnumTypeNode | InputObjectTypeNode | UnionTypeNode
+| CustomScalarTypeNode;
 
 export const DefinitionFromType = {
   [GQLNodeKind.OBJECT_DEFINITION]:GQLNodeKind.OBJECT_TYPE,
@@ -202,51 +200,51 @@ export const DefinitionFromType = {
   [GQLNodeKind.SCALAR_DEFINITION]:GQLNodeKind.CUSTOM_SCALAR_TYPE,
 };
 
-export interface ObjectTypeNode extends ReferenceTypeNode {
+export interface ObjectTypeNode extends ReferenceNode {
   kind:GQLNodeKind.OBJECT_TYPE;
 }
 
-export interface InterfaceTypeNode extends ReferenceTypeNode {
+export interface InterfaceTypeNode extends ReferenceNode {
   kind:GQLNodeKind.INTERFACE_TYPE;
 }
 
-export interface EnumTypeNode extends ReferenceTypeNode {
+export interface EnumTypeNode extends ReferenceNode {
   kind:GQLNodeKind.ENUM_TYPE;
 }
 
-export interface InputObjectTypeNode extends ReferenceTypeNode {
+export interface InputObjectTypeNode extends ReferenceNode {
   kind:GQLNodeKind.INPUT_OBJECT_TYPE;
 }
 
-export interface UnionTypeNode extends ReferenceTypeNode {
+export interface UnionTypeNode extends ReferenceNode {
   kind:GQLNodeKind.UNION_TYPE;
 }
 
 // Scalar Types
 
-export interface CustomScalarTypeNode extends ReferenceTypeNode {
+export interface CustomScalarTypeNode extends ReferenceNode {
   kind:GQLNodeKind.CUSTOM_SCALAR_TYPE;
 }
 
-export interface StringTypeNode extends GraphQLNode {
+export interface StringTypeNode extends NullableNode {
   kind:GQLNodeKind.STRING_TYPE;
 }
 
-export interface IntTypeNode extends GraphQLNode {
+export interface IntTypeNode extends NullableNode {
   kind:GQLNodeKind.INT_TYPE;
 }
 
-export interface FloatTypeNode extends GraphQLNode {
+export interface FloatTypeNode extends NullableNode {
   kind:GQLNodeKind.FLOAT_TYPE;
 }
 
 type NumberTypeNode = IntTypeNode | FloatTypeNode;
 
-export interface BooleanTypeNode extends GraphQLNode {
+export interface BooleanTypeNode extends NullableNode {
   kind:GQLNodeKind.BOOLEAN_TYPE;
 }
 
-export interface IDTypeNode extends GraphQLNode {
+export interface IDTypeNode extends NullableNode {
   kind:GQLNodeKind.ID_TYPE;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export interface UnionTypeDefinitionNode extends GraphQLDefinitionNode, Nullable
   members:ObjectTypeNode[];
 }
 
-export interface ScalarTypeDefinitionNode extends GraphQLDefinitionNode {
+export interface ScalarTypeDefinitionNode extends GraphQLDefinitionNode, NullableNode {
   kind:GQLDefinitionKind.SCALAR_DEFINITION;
   builtIn?:GQLTypeKind.INT_TYPE|GQLTypeKind.ID_TYPE;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,21 +81,24 @@ export interface GraphQLDefinitionNode extends TranspiledNode, NamedNode {
 export interface ObjectTypeDefinitionNode extends GraphQLDefinitionNode {
   kind:GQLDefinitionKind.OBJECT_DEFINITION;
   fields:OutputFieldDefinitionNode[];
+  implements:ReferenceNode[];
 }
 
 export interface InterfaceTypeDefinitionNode extends GraphQLDefinitionNode {
   kind:GQLDefinitionKind.INTERFACE_DEFINITION;
   fields:OutputFieldDefinitionNode[];
-}
-
-export interface EnumTypeDefinitionNode extends GraphQLDefinitionNode {
-  kind:GQLDefinitionKind.ENUM_DEFINITION;
-  values:string[];
+  implements:ReferenceNode[];
 }
 
 export interface InputObjectTypeDefinition extends GraphQLDefinitionNode {
   kind:GQLDefinitionKind.INPUT_OBJECT_DEFINITION;
   fields:InputFieldDefinitionNode[];
+  implements:ReferenceNode[];
+}
+
+export interface EnumTypeDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.ENUM_DEFINITION;
+  values:string[];
 }
 
 export interface UnionTypeDefinitionNode extends GraphQLDefinitionNode, NullableNode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import * as doctrine from 'doctrine';
-import { MethodParamsParser } from './Parser';
 
 export type SymbolName = string;
 
@@ -52,15 +51,15 @@ export enum GQLTypeKind {
 //
 // Abstractions
 //
-interface NamedNode {
+export interface NamedNode {
   name:SymbolName;
 }
 
-interface NullableNode {
+export interface NullableNode {
   nullable:boolean;
 }
 
-interface ReferenceNode extends NullableNode {
+export interface ReferenceNode extends NullableNode {
   target:SymbolName;
 }
 
@@ -75,7 +74,7 @@ export interface SchemaDefinitionNode extends TranspiledNode {
 //
 // Type Definitions
 //
-interface GraphQLDefinitionNode extends TranspiledNode, NamedNode {
+export interface GraphQLDefinitionNode extends TranspiledNode, NamedNode {
   kind:GQLDefinitionKind;
 }
 
@@ -159,7 +158,7 @@ export interface DirectiveInputValueNode extends GraphQLDefinitionNode {
 
 // General definitions
 
-interface GraphQLTypeNode extends TranspiledNode {
+export interface GraphQLTypeNode extends TranspiledNode {
   kind:GQLTypeKind;
 }
 
@@ -170,7 +169,7 @@ export enum GQLTypeCategory {
 
 export type NamedInputTypeNode = ScalarTypeNode | EnumTypeNode | InputObjectTypeNode;
 export type NamedOutputTypeNode = ScalarTypeNode | ObjectTypeNode | InterfaceTypeNode | UnionTypeNode | EnumTypeNode;
-type NamedTypeNode = NamedInputTypeNode | NamedOutputTypeNode;
+export type NamedTypeNode = NamedInputTypeNode | NamedOutputTypeNode;
 
 export type WrappingInputTypeNode = ListInputTypeNode;
 export type WrappingOutputTypeNode = ListOutputTypeNode;
@@ -182,7 +181,7 @@ export type TypeNode = NamedTypeNode | WrappingTypeNode;
 
 // Wrapping Types
 
-interface WrappingNode<T extends GraphQLTypeNode | ReferenceNode> extends GraphQLTypeNode, NullableNode {
+export interface WrappingNode<T extends GraphQLTypeNode | ReferenceNode> extends GraphQLTypeNode, NullableNode {
   wrapped:T;
 }
 
@@ -245,7 +244,7 @@ export interface FloatTypeNode extends GraphQLTypeNode, NullableNode {
   kind:GQLTypeKind.FLOAT_TYPE;
 }
 
-type NumberTypeNode = IntTypeNode | FloatTypeNode;
+export type NumberTypeNode = IntTypeNode | FloatTypeNode;
 
 export interface BooleanTypeNode extends GraphQLTypeNode, NullableNode {
   kind:GQLTypeKind.BOOLEAN_TYPE;

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,6 +200,7 @@ export type ReferenceTypeNode = ObjectTypeNode | InterfaceTypeNode | EnumTypeNod
 
 export const DefinitionFromType = {
   [GQLDefinitionKind.OBJECT_DEFINITION]:GQLTypeKind.OBJECT_TYPE,
+  [GQLDefinitionKind.INTERFACE_DEFINITION]:GQLTypeKind.INTERFACE_TYPE,
   [GQLDefinitionKind.ENUM_DEFINITION]:GQLTypeKind.ENUM_TYPE,
   [GQLDefinitionKind.INPUT_OBJECT_DEFINITION]:GQLTypeKind.INPUT_OBJECT_TYPE,
   [GQLDefinitionKind.UNION_DEFINITION]:GQLTypeKind.UNION_TYPE,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { ReferenceTypeNode } from './types';
 import * as doctrine from 'doctrine';
 
 export type SymbolName = string;
@@ -201,14 +202,14 @@ export type ListTypeNode = ListNode<NamedTypeNode>;
 export type ReferenceTypeNode = ObjectTypeNode | InterfaceTypeNode | EnumTypeNode | InputObjectTypeNode | UnionTypeNode
 | CustomScalarTypeNode;
 
-export const DefinitionFromType = {
-  [GQLDefinitionKind.OBJECT_DEFINITION]:GQLTypeKind.OBJECT_TYPE,
-  [GQLDefinitionKind.INTERFACE_DEFINITION]:GQLTypeKind.INTERFACE_TYPE,
-  [GQLDefinitionKind.ENUM_DEFINITION]:GQLTypeKind.ENUM_TYPE,
-  [GQLDefinitionKind.INPUT_OBJECT_DEFINITION]:GQLTypeKind.INPUT_OBJECT_TYPE,
-  [GQLDefinitionKind.UNION_DEFINITION]:GQLTypeKind.UNION_TYPE,
-  [GQLDefinitionKind.SCALAR_DEFINITION]:GQLTypeKind.CUSTOM_SCALAR_TYPE,
-};
+export const DefinitionFromType = new Map<GQLDefinitionKind, ReferenceTypeNode['kind']>([
+  [GQLDefinitionKind.OBJECT_DEFINITION, GQLTypeKind.OBJECT_TYPE],
+  [GQLDefinitionKind.INTERFACE_DEFINITION, GQLTypeKind.INTERFACE_TYPE],
+  [GQLDefinitionKind.ENUM_DEFINITION, GQLTypeKind.ENUM_TYPE],
+  [GQLDefinitionKind.INPUT_OBJECT_DEFINITION, GQLTypeKind.INPUT_OBJECT_TYPE],
+  [GQLDefinitionKind.UNION_DEFINITION, GQLTypeKind.UNION_TYPE],
+  [GQLDefinitionKind.SCALAR_DEFINITION, GQLTypeKind.CUSTOM_SCALAR_TYPE],
+]);
 
 export interface ObjectTypeNode extends GraphQLTypeNode, ReferenceNode {
   kind:GQLTypeKind.OBJECT_TYPE;

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,7 @@ export interface InputValueDefinitionNode extends NamedNode {
 
 export interface DirectiveDefinitionNode extends NamedNode {
   kind:GQLNodeKind.DIRECTIVE;
-  arguments:DirectiveInputValueNode[];
+  args:DirectiveInputValueNode[];
 }
 
 export interface DirectiveInputValueNode extends NamedNode {
@@ -251,17 +251,9 @@ export interface IDTypeNode extends NullableNode {
 export type BuiltInScalarTypeNode = StringTypeNode | NumberTypeNode | BooleanTypeNode | IDTypeNode;
 export type ScalarTypeNode = CustomScalarTypeNode | BuiltInScalarTypeNode;
 
-//
-// Misc
-//
-export interface StringLiteralNode {
-  type:GQLNodeKind.STRING_LITERAL;
-  value:string;
-}
-
 // Currently we have no distinction between values: they're string-represented
-export interface ValueNode {
-  type:GQLNodeKind.VALUE;
+export interface ValueNode extends GraphQLNode {
+  kind:GQLNodeKind.VALUE;
   value:string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,8 +68,8 @@ interface ReferenceNode extends NullableNode {
 // Root node
 //
 export interface SchemaDefinitionNode extends TranspiledNode {
-  query:ObjectTypeDefinitionNode;
-  mutation?:ObjectTypeDefinitionNode;
+  query:SymbolName;
+  mutation?:SymbolName;
 }
 
 //
@@ -116,7 +116,7 @@ export interface DefinitionAliasNode extends GraphQLDefinitionNode, NullableNode
 export type TypeDefinitionNode = ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode | EnumTypeDefinitionNode |
 InputObjectTypeDefinition | UnionTypeDefinitionNode | ScalarTypeDefinitionNode | DefinitionAliasNode;
 
-export type TypeDefinitionMap = {[key:string]:TypeDefinitionNode};
+export type TypeDefinitionMap = Map<string, TypeDefinitionNode>;
 
 //
 // Other Definitions
@@ -262,12 +262,4 @@ export type ScalarTypeNode = CustomScalarTypeNode | BuiltInScalarTypeNode;
 export interface ValueNode extends GraphQLTypeNode {
   kind:GQLTypeKind.VALUE;
   value:string;
-}
-
-export interface Parser<T> {
-  result:T;
-}
-
-export interface MethodParamsParser extends Parser<ArgumentsDefinitionNode> {
-
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -38,3 +38,16 @@ export function wrapNotNull(node:types.Node):types.NotNullNode {
     node,
   };
 }
+
+export function hasDocTag(node:types.TranspiledNode, prefix:string):boolean {
+  return !!getDocTag(node, prefix);
+}
+
+export function getDocTag(node:types.TranspiledNode, prefix:string):string|null {
+  if (!node.documentation) return null;
+  for (const tag of node.documentation.tags) {
+    if (tag.title !== 'graphql') continue;
+    if (tag.description.startsWith(prefix)) return tag.description;
+  }
+  return null;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -55,7 +55,8 @@ export function isScalar(node:types.TypeNode):node is types.ScalarTypeNode {
 
 export function isBuiltInScalar(node:types.TypeNode):node is types.BuiltInScalarTypeNode {
   return node.kind === types.GQLTypeKind.STRING_TYPE || node.kind === types.GQLTypeKind.INT_TYPE
-  || node.kind === types.GQLTypeKind.FLOAT_TYPE || node.kind === types.GQLTypeKind.BOOLEAN_TYPE;
+  || node.kind === types.GQLTypeKind.FLOAT_TYPE || node.kind === types.GQLTypeKind.BOOLEAN_TYPE
+  || node.kind === types.GQLTypeKind.ID_TYPE;
 }
 
 export function isWrappingType(node:types.TypeNode):node is types.WrappingTypeNode {

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,6 +33,12 @@ export function isReferenceType(node:types.TypeNode):node is types.ReferenceType
   node.kind === types.GQLTypeKind.UNION_TYPE || node.kind === types.GQLTypeKind.CUSTOM_SCALAR_TYPE;
 }
 
+export function isNullableDefinition(node:types.TypeDefinitionNode):node is types.UnionTypeDefinitionNode |
+types.ScalarTypeDefinitionNode  | types.DefinitionAliasNode {
+  return node.kind === types.GQLDefinitionKind.UNION_DEFINITION
+  || node.kind === types.GQLDefinitionKind.SCALAR_DEFINITION || node.kind === types.GQLDefinitionKind.DEFINITION_ALIAS;
+}
+
 export function isOutputType(node:types.TypeNode):node is types.OutputTypeNode {
   if (isWrappingType(node)) {
     return isOutputType(node.wrapped);

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,5 +54,5 @@ export function isBuiltInScalar(node:types.TypeNode):node is types.BuiltInScalar
 }
 
 export function isWrappingType(node:types.TypeNode):node is types.WrappingTypeNode {
-  return node.kind === types.GQLNodeKind.LIST_TYPE || node.kind === types.GQLNodeKind.NON_NULL_TYPE;
+  return node.kind === types.GQLNodeKind.LIST_TYPE;
 }

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -1,22 +1,21 @@
 import Emitter from '../../src/Emitter';
-import * as types from '../../src/types';
 import * as ts2gql from '../../src/index';
-import { UnionNode, AliasNode, EnumNode } from '../../src/types';
+import * as types from '../../src/types';
 
 describe(`Emitter`, () => {
 
-  let loadedTypes:types.TypeMap;
+  let loadedTypes:types.TypeDefinitionMap;
   let emitter:Emitter;
   beforeEach(() => {
-    loadedTypes = ts2gql.load('./test/schema.ts', ['Schema']);
-    emitter = new Emitter(loadedTypes);
+    const collector = ts2gql.load('./test/schema.ts', ['Schema']);
+    loadedTypes = collector.types;
+    emitter = new Emitter(collector);
   });
 
   describe(`_emitUnion`, () => {
     it(`emits GQL type union for union of interface types`, () => {
       const expected = `union FooSearchResult = Human | Droid | Starship`;
-      const aliasNode = loadedTypes['UnionOfInterfaceTypes'] as AliasNode;
-      const unionNode = aliasNode.target as UnionNode;
+      const unionNode = loadedTypes['UnionOfInterfaceTypes'] as types.UnionTypeDefinitionNode;
       const val = emitter._emitUnion(unionNode, 'FooSearchResult');
       expect(val).to.eq(expected);
     });
@@ -30,8 +29,7 @@ describe(`Emitter`, () => {
   Big
   Small
 }`;
-      const aliasNode = loadedTypes['UnionOfEnumTypes'] as AliasNode;
-      const unionNode = aliasNode.target as UnionNode;
+      const unionNode = loadedTypes['UnionOfEnumTypes'] as types.UnionTypeDefinitionNode;
       const val = emitter._emitUnion(unionNode, 'FooSearchResult');
       expect(val).to.eq(expected);
     });
@@ -46,31 +44,27 @@ describe(`Emitter`, () => {
   TOP
   BOTTOM
 }`;
-      const aliasNode = loadedTypes['QuarkFlavor'] as AliasNode;
-      const unionNode = aliasNode.target as UnionNode;
+      const unionNode = loadedTypes['QuarkFlavor'] as types.UnionTypeDefinitionNode;
       const val = emitter._emitUnion(unionNode, 'QuarkFlavor');
       expect(val).to.eq(expected);
     });
 
     it(`throws error if union combines interfaces with other node types`, () => {
-      const aliasNode = loadedTypes['UnionOfInterfaceAndOtherTypes'] as AliasNode;
-      const unionNode = aliasNode.target as UnionNode;
+      const unionNode = loadedTypes['UnionOfInterfaceAndOtherTypes'] as types.UnionTypeDefinitionNode;
       expect(() => {
         emitter._emitUnion(unionNode, 'FooSearchResult');
       }).to.throw('ts2gql expected a union of only interfaces since first child is an interface. Got a reference');
     });
 
     it(`throws error if union combines enums with other node types`, () => {
-      const aliasNode = loadedTypes['UnionOfEnumAndOtherTypes'] as AliasNode;
-      const unionNode = aliasNode.target as UnionNode;
+      const unionNode = loadedTypes['UnionOfEnumAndOtherTypes'] as types.UnionTypeDefinitionNode;
       expect(() => {
         emitter._emitUnion(unionNode, 'FooSearchResult');
       }).to.throw('ts2gql expected a union of only enums since first child is an enum. Got a reference');
     });
 
     it(`throws error if union contains non-reference types`, () => {
-      const aliasNode = loadedTypes['UnionOfNonReferenceTypes'] as AliasNode;
-      const unionNode = aliasNode.target as UnionNode;
+      const unionNode = loadedTypes['UnionOfNonReferenceTypes'] as types.UnionTypeDefinitionNode;
       expect(() => {
         emitter._emitUnion(unionNode, 'FooSearchResult');
       }).to.throw('GraphQL unions require that all types are references. Got a boolean');
@@ -85,7 +79,7 @@ describe(`Emitter`, () => {
   CIRCUMBINARY
   PLUTOID
 }`;
-      const enumNode = loadedTypes['Planet'] as EnumNode;
+      const enumNode = loadedTypes['Planet'] as types.EnumTypeDefinitionNode;
       const val = emitter._emitEnum(enumNode, 'Planet');
       expect(val).to.eq(expected);
     });
@@ -98,7 +92,7 @@ describe(`Emitter`, () => {
   FALL
   WINTER
 }`;
-      const enumNode = loadedTypes['Seasons'] as EnumNode;
+      const enumNode = loadedTypes['Seasons'] as types.EnumTypeDefinitionNode;
       const val = emitter._emitEnum(enumNode, 'Seasons');
       expect(val).to.eq(expected);
     });
@@ -110,7 +104,7 @@ describe(`Emitter`, () => {
   CIRROCUMULUS
   CUMULONIMBUS
 }`;
-      const enumNode = loadedTypes['Cloud'] as EnumNode;
+      const enumNode = loadedTypes['Cloud'] as types.EnumTypeDefinitionNode;
       const val = emitter._emitEnum(enumNode, 'Cloud');
       expect(val).to.eq(expected);
     });
@@ -122,7 +116,7 @@ describe(`Emitter`, () => {
   SECOND
   THIRD
 }`;
-      const enumNode = loadedTypes['Ordinal'] as EnumNode;
+      const enumNode = loadedTypes['Ordinal'] as types.EnumTypeDefinitionNode;
       const val = emitter._emitEnum(enumNode, 'Ordinal');
       expect(val).to.eq(expected);
     });


### PR DESCRIPTION
### Why
This drastically changes ts2gql type system. The main purpose is to separate TypeScript and GraphQL abstractions, making ts2gql node types trivially translatable to GraphQL. This brings great simplification to the `Emitter` layer and, mainly, caused true separation of concerns between Emission and Collection.

### How

This new type system was inspired in TypeScript Nodes Types of the TypeScript Compiler API and followed rigorously the concepts of the [official GraphQL SDL Description](https://facebook.github.io/graphql/June2018/).

Now there are types for every concept of GraphQL and two division of nodes: *DefinitionNodes* and *TypeNodes*.

*DefinitionNodes* collect the proper node content and may be `TypeDefinition` or just `Definition`.
`TypeDefinitions` are immediately equivalent to the related GraphQL concept except the`DefinitionAliasNode`, created to make use of some TypeScript's useful ability of creating aliases for types. The possible *TypeDefinitionNodes* are
- `ObjectTypeDefinitionNode`
- `InterfaceTypeDefinitionNode`
- `InputObjectTypeDefinition`
- `EnumTypeDefinitionNode`
- `UnionTypeDefinitionNode`
- `ScalarTypeDefinitionNode`
- `DefinitionAliasNode`

Remaining *DefinitionNodes* serve to modularize other definitions, like fields, directives and arguments.
- `FieldDefinitionNode`
- `InputValueDefinitionNode`
- `DirectiveDefinitionNode`
- `DirectiveInputValueNode`

*TypeNodes* do not have content once they are TypeScript expressions. They may be translated from TypeScript unions, JavaScript builtins, TypeScript Type References, etc. They are
- `ObjectTypeNode`
- `InterfaceTypeNode`
- `EnumTypeNode`
- `InputObjectTypeNode`
- `UnionTypeNode`
- `CustomScalarTypeNode`
- `StringTypeNode`
- `IntTypeNode`
- `FloatTypeNode`
- `BooleanTypeNode`
- `IDTypeNode`
There is also `ListNode`, the equivalent to the List Wrapping Type of GraphQL SDL, and `ValueNode` to denote directives' argument lists contents.

Now deciding whether a *TypeNode* is *Required* or not is done by managing a simple `nullable` property introduced by the `NullableNode` type. This specifies without ambiguities which kind of Node may be nullable and permits Nullable characteristic propagation even when it's identified during collection of a *DefinitionNode*.

Type Checking and other safety semantical verifications are more natural this way and easier to separate in different clauses. Better error messages have substituted previous undefined behaviors.

### Breaking changes
- Fix a number of bugs that may have been exploited by users incorrectly.
- Primitively aliasing a defined type now copies the type content. This is a more intuitive usage than the previous (Create a GraphQL Union with a single member).
### Issues
- Not accepting circular references anymore.
- Not accepting union of enums