### PR TITLE
Include file and line at error messages

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -10,7 +10,6 @@ export default class Emitter {
   private root:types.SchemaDefinitionNode;
   constructor(collector:CollectorType) {
     this.typeMap = collector.types;
-    // console.log(JSON.stringify([...this.typeMap], undefined, 1))
     if (!collector.root) {
       throw new Error(`Empty schema definition.`);
     }

--- a/src/Exceptions.ts
+++ b/src/Exceptions.ts
@@ -1,0 +1,56 @@
+import * as typescript from 'typescript';
+
+export class TranspilationError extends Error {
+    protected fileName:string;
+    protected lineNumber:number;
+    constructor(node:typescript.Node, msg:string) {
+        super(msg);
+        const src = node.getSourceFile();
+        this.fileName = fileOnly(src.fileName);
+        this.lineNumber = src.getLineAndCharacterOfPosition(node.getStart(src, false)).line + 1;
+    }
+
+    protected fileAndLine = ():string => {
+        return `(${this.fileName}:${this.lineNumber})`;
+    }
+}
+
+export class InterfaceError extends TranspilationError {
+    constructor(node:typescript.InterfaceDeclaration, msg:string) {
+        super(node, msg);
+        this.message = `At interface '${node.name.getText()}'${this.fileAndLine()}\n${this.message}`;
+    }
+}
+
+export class PropertyError extends TranspilationError {
+    constructor(node:typescript.TypeElement, msg:string) {
+        super(node, msg);
+        this.message = `At property '${node.name!.getText()}'${this.fileAndLine()}\n${this.message}`;
+    }
+}
+
+export class InputValueError extends TranspilationError {
+    constructor(node:typescript.ParameterDeclaration, msg:string) {
+        super(node, msg);
+        this.message = `At parameter '${node.name.getText()}'${this.fileAndLine()}\n${this.message}`;
+    }
+}
+
+export class TypeAliasError extends TranspilationError {
+    constructor(node:typescript.TypeAliasDeclaration, msg:string) {
+        super(node, msg);
+        this.message = `At type '${node.name.getText()}'${this.fileAndLine()}\n${this.message}`;
+    }
+}
+
+export class EnumError extends TranspilationError {
+    constructor(node:typescript.EnumDeclaration, msg:string) {
+        super(node, msg);
+        this.message = `At enum '${node.name.getText()}'${this.fileAndLine()}\n${this.message}`;
+    }
+}
+
+const fileOnly = (path:string):string => {
+    const splitted = path.split('/');
+    return splitted[splitted.length - 1];
+};

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -11,13 +11,12 @@ export class MethodParamsParser  {
     constructor() {
         this.tokenizer = new MethodParamsTokenizer();
         this.tokens = [];
-        this.args = {} as Map<string, types.DirectiveInputValueNode>;
+        this.args = new Map<string, types.DirectiveInputValueNode>();
     }
 
     parse(stringToParse:string):types.DirectiveInputValueNode[] {
         this.tokens = this.tokenizer.tokenize(stringToParse);
-        this._parseArgs();
-        return Array.from(this.args.values());
+        return Array.from(this._parseArgs().values());
     }
 
     _parseArgs():Map<string, types.DirectiveInputValueNode> {
@@ -50,17 +49,17 @@ export class MethodParamsParser  {
             \n${valueToken.type}: ${valueToken.value}`);
         }
 
-        if (this.args[nameToken.value]) {
-            throw new ParsingFailedException(`Repeated param name ${nameToken.value}.`);
+        if (this.args.get(nameToken.value)) {
+            throw new ParsingFailedException(`Repeated param name '${nameToken.value}'.`);
         }
-        this.args[nameToken.value] = {
+        this.args.set(nameToken.value, {
             name: nameToken.value,
             kind: types.GQLDefinitionKind.DIRECTIVE_INPUT_VALUE_DEFINITION,
             value: {
                 kind: types.GQLTypeKind.VALUE,
                 value: valueToken.value,
             },
-        };
+        });
 
         return start + 3;
     }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -112,7 +112,7 @@ export class MethodParamsTokenizer {
         const value = this.raw.slice(idx, valueEnd);
         if (!this._checkPrimitiveValue(value)) {
             const msg = value.length === 0 ? `Missing value`
-            : `Invalid value '${value}'. Expected number, boolean, string literal or name'`;
+            : `Invalid value '${value}'. Expected number, boolean, string literal or name`;
             throw new MethodParamsTokenizerException(msg);
         }
         this.tokens.push(new MethodParamsToken(TokenType.PARAMETER_VALUE, value));


### PR DESCRIPTION
This PR adds support for showing exact file and line for errors thrown during the transpilation process.
The error are in the format
```
At <typescript node type>(<file>:<line>)
<message>
```
And are propagated up to acquire an exact trace of the transpilation course.

This can be tested by trying to transpile any invalid `.ts` file.