### PR TITLE
Support GraphQL Descriptions

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -136,7 +136,11 @@ export default class Emitter {
   }
 
   _emitEnum(node:types.EnumTypeDefinitionNode, name:types.SymbolName):string {
-    return `enum ${this._name(name)} {\n${this._indent(node.values)}\n}`;
+    return `enum ${this._name(name)} {\n${this._emitEnumFields(node.fields)}\n}`;
+  }
+
+  _emitEnumFields(fields:types.EnumFieldDefinitionNode[]):string {
+    return fields.map(field => this._indent(this._emitDescription(field.description) + field.name)).join('\n');
   }
 
   _emitUnion(node:types.UnionTypeDefinitionNode, name:types.SymbolName):string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type SymbolName = string;
 
 export interface TranspiledNode {
   documentation?:doctrine.ParseResult;
+  description?:string;
   originalLine?:number;
   originalColumn?:number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export enum GQLDefinitionKind {
   SCALAR_DEFINITION = 'scalar definition',
   FIELD_DEFINITION = 'field definition',
   INPUT_VALUE_DEFINITION = 'input value definition',
+  ENUM_FIELD_DEFINITION = 'enum field definition',
   DEFINITION_ALIAS = 'definition alias',
   // Directives
   DIRECTIVE = 'directive',
@@ -100,7 +101,7 @@ export interface InputObjectTypeDefinition extends GraphQLDefinitionNode {
 
 export interface EnumTypeDefinitionNode extends GraphQLDefinitionNode {
   kind:GQLDefinitionKind.ENUM_DEFINITION;
-  values:string[];
+  fields:EnumFieldDefinitionNode[];
 }
 
 export interface UnionTypeDefinitionNode extends GraphQLDefinitionNode, NullableNode {
@@ -157,6 +158,10 @@ export interface DirectiveDefinitionNode extends GraphQLDefinitionNode {
 export interface DirectiveInputValueNode extends GraphQLDefinitionNode {
   kind:GQLDefinitionKind.DIRECTIVE_INPUT_VALUE_DEFINITION;
   value:ValueNode;
+}
+
+export interface EnumFieldDefinitionNode extends GraphQLDefinitionNode {
+  kind:GQLDefinitionKind.ENUM_FIELD_DEFINITION;
 }
 
 //

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,9 +22,9 @@ export function hasDocTag(node:types.TranspiledNode, regex:RegExp):boolean {
 export function extractTagDescription(doc:doctrine.ParseResult|undefined, regex:RegExp):string|null {
   if (!doc) return null;
   const found = doc.tags.find((tag) => {
-    return tag.title === 'graphql' && regex.test(tag.description);
+    return tag.title === 'graphql' && regex.test(String(tag.description));
   });
-  return found ? found.description : null;
+  return found ? String(found.description) : null;
 }
 
 export function isReferenceType(node:types.TypeNode):node is types.ReferenceTypeNode {


### PR DESCRIPTION
Allow users to define GraphQL Descriptions that can be captured by the GraphQL server.

The usage is by a JSDoc Tag `@graphql description`. Anything after this will become a description. For instance
```ts
interface A {
    a:string;
}
interface C {
    c:string;
}
/** @graphql Description Some usual union */
type a = A | C;
/** @graphql Description Some unusual alias */
type b = C | null;
/** @graphql Description Some usual enum */
enum E {
    /** @graphql Description Some usual enum field */
    e,
}
/** @graphql Description
 * Multiline
 * Description of Query */
interface Query {
    /** @graphql Description Inline description of field */
    test1:a;
    test2:b;
    /** @graphql Description
     * Very
     * 
     * Multiline
     * Description that can be combined with directives in a single JSDoc
     * @graphql directives
     * @someDirective
     * @someOtherDirective (arg:"value")
     */
    test3:C;
    test4:E;
}

/** @graphql Schema */
export interface Schema {
    query:Query;
}
```
Generates
```gql
type A {
  a: String!
}

type C {
  c: String!
}

"""
Some usual union
"""
union a = A | C

"""
Some unusual alias
"""
type b {
  c: String!
}

"""
Some usual enum
"""
enum E {
  """
  Some usual enum field
  """
  e
}

"""
Multiline
Description of Query
"""
type Query {
  """
  Inline description of field
  """
  test1: a!
  test2: b
  """
  Very
  
  Multiline
  Description that can be combined with directives in a single JSDoc
  """
  test3: C! @someDirective @someOtherDirective(arg: "value")
  test4: E!
}

schema {
  query: Query
}
```