### PR TITLE
Allow recursive build of enums from smaller enums

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -72,7 +72,7 @@ export default class Emitter {
         throw new Error(`Unsupported top level node '${name}'.`);
     }
     this.emissionQueue.push(name);
-    this.emissionMap.set(name, content);
+    this.emissionMap.set(name, description + content);
   }
 
   _emitSchema() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,7 @@ export interface InputObjectTypeDefinition extends GraphQLDefinitionNode {
   implements:ReferenceNode[];
 }
 
-export interface EnumTypeDefinitionNode extends GraphQLDefinitionNode {
+export interface EnumTypeDefinitionNode extends GraphQLDefinitionNode, NullableNode {
   kind:GQLDefinitionKind.ENUM_DEFINITION;
   fields:EnumFieldDefinitionNode[];
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -34,9 +34,10 @@ export function isReferenceType(node:types.TypeNode):node is types.ReferenceType
 }
 
 export function isNullableDefinition(node:types.TypeDefinitionNode):node is types.UnionTypeDefinitionNode |
-types.ScalarTypeDefinitionNode  | types.DefinitionAliasNode {
+types.EnumTypeDefinitionNode | types.ScalarTypeDefinitionNode  | types.DefinitionAliasNode {
   return node.kind === types.GQLDefinitionKind.UNION_DEFINITION
-  || node.kind === types.GQLDefinitionKind.SCALAR_DEFINITION || node.kind === types.GQLDefinitionKind.DEFINITION_ALIAS;
+  || node.kind === types.GQLDefinitionKind.ENUM_DEFINITION || node.kind === types.GQLDefinitionKind.SCALAR_DEFINITION
+  || node.kind === types.GQLDefinitionKind.DEFINITION_ALIAS;
 }
 
 export function isOutputType(node:types.TypeNode):node is types.OutputTypeNode {


### PR DESCRIPTION
This new feature permits the ts2gql transpiler to recursively build Enums from smaller ones.
The basic usage would be:
```ts
enum D {
    d,
    dd,
    e,
}
enum E {
    e,
}
type Merged = D | E;
interface Query {
    test:Merged;
}
/** @graphql Schema */
export interface Schema {
    query:Query;
}
```
Transpiling to
```gql

enum D {
  d
  dd
  e
}

enum E {
  e
}

enum Merged {
  d
  dd
  e
}

type Query {
  test: Merged!
}

schema {
  query: Query
}
```