### PR TITLE
Allow recursive build of unions from smaller unions

### DIFF
--- a/src/Collector.ts
+++ b/src/Collector.ts
@@ -188,6 +188,18 @@ export class Collector implements CollectorType {
     return name ? this._collectUnionDefinition(node, name, doc) : this._collectUnionExpression(node);
   }
 
+  _walkUnionMembersFlat(unionTypes:typescript.Node[]):types.TypeNode[] {
+    const collectedMembers = unionTypes.map((type) => {
+      const collected = this._walkType(type);
+      if (collected.kind !== types.GQLTypeKind.UNION_TYPE) {
+        return collected;
+      }
+      const referenced = this.types.get(collected.target)! as types.UnionTypeDefinitionNode;
+      return referenced.members;
+    });
+    return _.flatten<types.TypeNode>(collectedMembers);
+  }
+
   //
   // GraphQL Node Collecting
   //
@@ -543,7 +555,7 @@ export class Collector implements CollectorType {
   doc?:doctrine.ParseResult):types.UnionTypeDefinitionNode | types.ScalarTypeDefinitionNode
   | types.EnumTypeDefinitionNode | types.DefinitionAliasNode {
     const description = this._collectDescription(doc);
-    const unionMembers = this._filterNullUndefined(node.types).map(this._walkType);
+    const unionMembers = this._walkUnionMembersFlat(this._filterNullUndefined(node.types));
     const nullable = unionMembers.length < node.types.length || unionMembers.every(member => member.nullable);
 
     // Only one member: create alias nullable by default
@@ -602,7 +614,7 @@ export class Collector implements CollectorType {
       kind: types.GQLDefinitionKind.UNION_DEFINITION,
       name,
       nullable,
-      members: collectedUnion,
+      members: _.uniqBy(collectedUnion, member => member.target),
     };
   }
 


### PR DESCRIPTION
This features allows the transpiler to recursively build unions from smaller ones.
Basic usage is
```ts
interface A {
    a:string;
}
interface B {
    b:string;
}
interface C {
    c:string;
}
type AB = A | B;
type BC = B | C;
type ABC = AB | BC;
interface Query {
    test:ABC;
}
/** @graphql Schema */
export interface Schema {
    query:Query;
}
```
```gql
type B {
  b: String!
}
type C {
  c: String!
}
type A {
  a: String!
}
union ABC = A | B | C
type Query {
  test: ABC!
}
schema {
  query: Query
}
```