### PR TITLE
Allow general circular referencing

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -66,8 +66,11 @@ export default class Emitter {
         break;
       case types.GQLDefinitionKind.DEFINITION_ALIAS:
         const aliased = this.typeMap.get(node.target)!;
+        if (aliased.name === name) {
+          throw new Error(`Can not emit alias with same name of original type.`);
+        }
         content = this._emitTopLevelNode(aliased, name);
-        return;
+        break;
       default:
         throw new Error(`Unsupported top level node '${name}'.`);
     }

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -32,7 +32,7 @@ export default class Emitter {
       const mutationRootName = this._name(this.root.mutation!);
       this._emitTopLevelNode(mutation, mutationRootName);
     }
-    this.emissionQueue.forEach(emissionElem => stream.write(`${this.emissionMap.get(emissionElem)!}\n`));
+    this.emissionQueue.forEach(emissionElem => stream.write(`${this.emissionMap.get(emissionElem)}\n`));
     stream.write(`${this._emitSchema()}\n`);
   }
 
@@ -70,7 +70,7 @@ export default class Emitter {
           throw new Error(`Can not emit alias with same name of original type.`);
         }
         content = this._emitTopLevelNode(aliased, name);
-        break;
+        return;
       default:
         throw new Error(`Unsupported top level node '${name}'.`);
     }

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -11,7 +11,7 @@ export default class Emitter {
   private emissionMap:Map<types.SymbolName, string> = new Map();
   private emissionQueue:types.SymbolName[] = [];
   constructor(collector:CollectorType) {
-    this.typeMap = collector.types;
+    this.typeMap = collector.resolved;
     if (!collector.root) {
       throw new Error(`Empty schema definition.`);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export enum GQLTypeKind {
   ENUM_TYPE = 'enum type',
   INPUT_OBJECT_TYPE = 'input object type',
   UNION_TYPE = 'union type',
+  CIRCULAR_TYPE = 'circular type',
   CUSTOM_SCALAR_TYPE = 'custom scalar',
   STRING_TYPE = 'string',
   INT_TYPE = 'int',
@@ -181,7 +182,7 @@ export enum GQLTypeCategory {
 
 export type NamedInputTypeNode = ScalarTypeNode | EnumTypeNode | InputObjectTypeNode;
 export type NamedOutputTypeNode = ScalarTypeNode | ObjectTypeNode | InterfaceTypeNode | UnionTypeNode | EnumTypeNode;
-export type NamedTypeNode = NamedInputTypeNode | NamedOutputTypeNode;
+export type NamedTypeNode = NamedInputTypeNode | NamedOutputTypeNode | CircularReferenceTypeNode;
 
 export type WrappingInputTypeNode = ListInputTypeNode;
 export type WrappingOutputTypeNode = ListOutputTypeNode;
@@ -208,7 +209,7 @@ export type ListTypeNode = ListNode<NamedTypeNode>;
 // Named Types
 
 export type ReferenceTypeNode = ObjectTypeNode | InterfaceTypeNode | EnumTypeNode | InputObjectTypeNode | UnionTypeNode
-| CustomScalarTypeNode;
+| CustomScalarTypeNode | CircularReferenceTypeNode;
 
 export const DefinitionFromType = new Map<GQLDefinitionKind, ReferenceTypeNode['kind']>([
   [GQLDefinitionKind.OBJECT_DEFINITION, GQLTypeKind.OBJECT_TYPE],
@@ -237,6 +238,12 @@ export interface InputObjectTypeNode extends GraphQLTypeNode, ReferenceNode {
 
 export interface UnionTypeNode extends GraphQLTypeNode, ReferenceNode {
   kind:GQLTypeKind.UNION_TYPE;
+}
+
+// This type is a reference to a unresolved definition
+// Definitions having this type as leaf must assume it is according to expectations
+export interface CircularReferenceTypeNode extends GraphQLTypeNode, ReferenceNode {
+  kind:GQLTypeKind.CIRCULAR_TYPE;
 }
 
 // Scalar Types

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,7 +30,8 @@ export function extractTagDescription(doc:doctrine.ParseResult|undefined, regex:
 export function isReferenceType(node:types.TypeNode):node is types.ReferenceTypeNode {
   return node.kind === types.GQLTypeKind.OBJECT_TYPE || node.kind === types.GQLTypeKind.INTERFACE_TYPE ||
   node.kind === types.GQLTypeKind.ENUM_TYPE || node.kind === types.GQLTypeKind.INPUT_OBJECT_TYPE ||
-  node.kind === types.GQLTypeKind.UNION_TYPE || node.kind === types.GQLTypeKind.CUSTOM_SCALAR_TYPE;
+  node.kind === types.GQLTypeKind.UNION_TYPE || node.kind === types.GQLTypeKind.CUSTOM_SCALAR_TYPE ||
+  node.kind === types.GQLTypeKind.CIRCULAR_TYPE;
 }
 
 export function isNullableDefinition(node:types.TypeDefinitionNode):node is types.UnionTypeDefinitionNode |

--- a/test/integration/Emitter.ts
+++ b/test/integration/Emitter.ts
@@ -8,7 +8,7 @@ describe(`Emitter`, () => {
   let emitter:Emitter;
   beforeEach(() => {
     const collector = ts2gql.load('./test/schema.ts', ['Schema']);
-    loadedTypes = collector.types;
+    loadedTypes = collector.resolved;
     emitter = new Emitter(collector);
   });
 


### PR DESCRIPTION
This PR allows ts2gql to transpile type when circularly referenced.
Circular references are handled case to case, but the general strategy is to recognize if the referenced type reliably is in the set of allowed types. If so, an inference is given.

For example, if a GraphQL Input is referenced, it may only be initially from an **argument list**. If not, an error is garanteed to be thrown so we can take that for granted. Once this happens, any further referencing can not be pointed to an GraphQL Object or Graphql Interface. This means that within an GraphQL Input Object we can garantee that any circular referencing to an TypeScript Interface is also an GraphQL Input Object and if this doesn't happen, an error will be thrown.

When there's no way to garantee reliably that the circular type is according to expectations (for example, using type aliases, there's no way of telling what the alias refer to untill it's resolved), it is needed to schedule resolving for when the referenced type is finally resolved.

This means that this PR does not cover 100% of the cases, since there can exist tricky cases where this strategy may for a loop that one type may need to wait for itself to resolve so it can resolve itself. This usually leads to stack overflow errors. Luckly, most of these cases are conceptually wrong and TypeScript itself warns with errors. Furthermore, there are cases forbidden by TypeScript that are actually well resolved by the transpiler.